### PR TITLE
docker-centos: change propagation to shared

### DIFF
--- a/docker-centos/config.json.template
+++ b/docker-centos/config.json.template
@@ -109,7 +109,7 @@
 	    "destination": "/var/lib",
 	    "options": [
 		"rbind",
-		"shared",
+		"rshared",
 		"rw",
 		"mode=755"
 	    ]
@@ -160,7 +160,7 @@
     ],
     "hooks": {},
     "linux": {
-	"rootfsPropagation" : "rslave",
+	"rootfsPropagation" : "shared",
 	"resources": {
 	    "devices": [
 		{


### PR DESCRIPTION
Or "-v FROM:TO:shared" would not work correctly.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>