### PR TITLE
[merged] docker-centos: change /dev from bind to rbind

### DIFF
--- a/docker-centos/config.json.template
+++ b/docker-centos/config.json.template
@@ -70,7 +70,7 @@
 	    "destination": "/dev",
 	    "type": "bind",
 	    "options": [
-		"bind",
+		"rbind",
 		"shared",
 		"rw",
 		"mode=755"


### PR DESCRIPTION
otherwise we cannot create pttys in /dev/pts

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>