### PR TITLE
[merged] Docker on Rawhide: better support for live restore

### DIFF
--- a/docker-centos/service.template
+++ b/docker-centos/service.template
@@ -17,7 +17,6 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
 TimeoutStartSec=0
-MountFlags=shared
 
 [Install]
 WantedBy=multi-user.target

--- a/docker-fedora/Dockerfile
+++ b/docker-fedora/Dockerfile
@@ -1,8 +1,9 @@
 FROM fedora:rawhide
 MAINTAINER Giuseppe Scrivano <gscrivan@redhat.com>
 
-RUN dnf install -y docker docker-selinux cloud-utils-growpart python-docker-py docker-novolume-plugin lvm2 iptables procps-ng xz && dnf clean all
-ADD shim.sh init.sh init-wrapper.sh /usr/bin/
+ADD mount-in-ns.c /root
+RUN dnf install -y gcc docker docker-selinux cloud-utils-growpart python-docker-py docker-novolume-plugin lvm2 iptables procps-ng xz inotify-tools && gcc /root/mount-in-ns.c -o /usr/bin/mount-in-ns && mkdir -p /usr/lib/modules && dnf clean all
+ADD shim.sh init.sh init-wrapper.sh setup-keep-alive-process.sh /usr/bin/
 
 # system container
 COPY service.template tmpfiles.template config.json.template /exports/

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -14,6 +14,7 @@
 	    "/usr/bin/init-wrapper.sh"
 	],
 	"env": [
+	    "DESTDIR=$DESTDIR",
 	    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	    "TERM=xterm",
             "NAME=$NAME"
@@ -91,14 +92,18 @@
 	{
 	    "destination": "/proc",
 	    "type": "proc",
-	    "source": "proc"
+	    "source": "proc",
+            "options": [
+                "rprivate",
+                "mode=755"
+            ]
 	},
 	{
 	    "type": "bind",
 	    "source": "/run",
 	    "destination": "/run",
 	    "options": [
-		"rprivate",
+		"shared",
 		"rbind",
 		"rw",
 		"mode=755"
@@ -109,7 +114,7 @@
 	    "destination": "/tmp",
 	    "type": "bind",
 	    "options": [
-		"rprivate",
+		"shared",
 		"rbind",
 		"rw",
 		"mode=755"
@@ -126,31 +131,22 @@
 	},
 	{
 	    "type": "bind",
-	    "source": "/",
-	    "destination": "/host",
-	    "options": [
-		"rbind",
-		"rshared"
-	    ]
-	},
-	{
-	    "type": "bind",
 	    "source": "/etc",
 	    "destination": "/etc",
 	    "options": [
 		"rbind",
-		"rprivate",
+		"shared",
 		"rw",
 		"mode=755"
 	    ]
 	},
 	{
 	    "type": "bind",
-	    "source": "/lib/modules",
-	    "destination": "/lib/modules",
+	    "source": "/",
+	    "destination": "/host",
 	    "options": [
 		"rbind",
-		"rprivate",
+		"shared",
 		"rw",
 		"mode=755"
 	    ]
@@ -161,7 +157,7 @@
 	    "destination": "/root",
 	    "options": [
 		"rbind",
-		"rprivate",
+		"shared",
 		"rw",
 		"mode=755"
 	    ]
@@ -172,7 +168,7 @@
 	    "destination": "/home",
 	    "options": [
 		"rbind",
-		"rprivate",
+		"shared",
 		"rw",
 		"mode=755"
 	    ]
@@ -184,7 +180,7 @@
 	    "options": [
 		"rbind",
 		"rw",
-		"rprivate",
+		"shared",
 		"mode=755"
             ]
 	},
@@ -193,7 +189,7 @@
 	    "source": "/usr/share/rhel",
 	    "destination": "/usr/share/rhel",
 	    "options": [
-		"rprivate",
+		"shared",
 		"rbind",
 		"ro",
 		"mode=755"
@@ -202,7 +198,7 @@
     ],
     "hooks": {},
     "linux": {
-	"rootfsPropagation": "shared",
+	"rootfsPropagation": "rslave",
 	"resources": {
 	    "devices": [
 		{

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -89,15 +89,9 @@
 	    ]
 	},
 	{
-	    "source": "/proc",
 	    "destination": "/proc",
-	    "type": "bind",
-	    "options": [
-		"rprivate",
-		"rbind",
-		"rw",
-		"mode=755"
-	    ]
+	    "type": "proc",
+	    "source": "proc"
 	},
 	{
 	    "type": "bind",

--- a/docker-fedora/init.sh
+++ b/docker-fedora/init.sh
@@ -6,6 +6,8 @@
     /usr/bin/docker-storage-setup
 )
 
+getent group docker || groupadd docker
+
 source /run/docker-bash-env
 
 /usr/libexec/docker/docker-containerd-current \

--- a/docker-fedora/mount-in-ns.c
+++ b/docker-fedora/mount-in-ns.c
@@ -1,0 +1,31 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <error.h>
+#include <errno.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <stdlib.h>
+#include <sys/mount.h>
+
+int main(int argc, char *argv[])
+{
+  int ret, targetfd;
+  char ns[PATH_MAX];
+
+  if (argc <= 3)
+    error (EXIT_FAILURE, 0, "Not enough params");
+
+  sprintf (ns, "/proc/%s/ns/mnt", argv[1]);
+  targetfd = open (ns, O_RDONLY);
+
+  if (setns (targetfd, CLONE_NEWNS))
+    error (EXIT_FAILURE, errno, "setns");
+
+  umount2 (argv[3], MNT_DETACH);
+  ret = mount (argv[2], argv[3], NULL, MS_MGC_VAL | MS_BIND | MS_REC, NULL);
+  if (ret < 0)
+    error (EXIT_FAILURE, errno, "mount");
+
+  return 0;
+}

--- a/docker-fedora/service.template
+++ b/docker-fedora/service.template
@@ -7,7 +7,6 @@ EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/sysconfig/docker-network
 Environment=GOTRACEBACK=crash
-ExecStartPre=/bin/sh -c "(mountpoint -q /var/lib/docker || mount --bind /var/lib/docker /var/lib/docker) && mount --make-shared /var/lib/docker"
 ExecStartPre=/bin/bash -c 'export -p > /run/docker-bash-env'
 ExecStart=/bin/runc --systemd-cgroup run $NAME
 ExecStop=/bin/runc kill $NAME

--- a/docker-fedora/setup-keep-alive-process.sh
+++ b/docker-fedora/setup-keep-alive-process.sh
@@ -1,0 +1,50 @@
+#/usr/bin/bash
+
+set -euo pipefail
+
+# we are running in a new mount namespace, move ourselves in a tmpfs or we cannot access
+# the container when the rootfs is deleted (for example on an update).
+
+mkdir -p /run/docker/keep-alive
+mount -t tmpfs tmpfs /run/docker/keep-alive
+mkdir -p /run/docker/keep-alive/{old,usr,run}
+
+cp -P /bin /lib /lib64 /sbin /run/docker/keep-alive
+
+MOUNTS="dev proc sys"
+MOUNTS_MOVEABLE="etc home mnt tmp root var/lib/docker host usr/share/rhel"
+
+mount --bind /usr /run/docker/keep-alive/usr
+mount --bind /run /run/docker/keep-alive/run
+
+for i in $MOUNTS_MOVEABLE
+do
+    mkdir -p /run/docker/keep-alive/$i
+    mount --move $i /run/docker/keep-alive/$i
+done
+
+mkdir -p /run/docker/keep-alive/var/run
+mount --rbind  /var/run /run/docker/keep-alive/var/run
+
+for i in $MOUNTS
+do
+    mkdir -p /run/docker/keep-alive/$i
+    mount --bind $i /run/docker/keep-alive/$i
+done
+
+cd /run/docker/keep-alive
+
+pivot_root . old
+
+mount --move old/sys /sys
+mount --move old/proc /proc
+mount --move old/dev /dev
+mount --move old/run /run
+
+# /usr/lib/modules comes from the host
+mount --bind /host/usr/lib/modules /usr/lib/modules
+
+echo $BASHPID > /run/docker/docker-wrapper.pid
+
+# keep alive process to use to later join the same mount namespace
+exec systemd-run --no-block --scope -q inotifywait -e delete_self /var/lib/docker/containers >/dev/null 2>&1


### PR DESCRIPTION
The previous version was completely broken in case of an upgrade, which is the main reason of having live restore.

This is still a proof of concept, but now Docker containers upgrades are supported.  If we'll decide to go this way, most of the scripts and the new `mount-in-ns` tool must be cleaned up.

Another solution to investigate is to use a chroot directly into /var/lib/containers/atomic/docker.0/rootfs instead of a container so that we do not have to deal with different namespaces, at the cost of dealing with the new mount points in the host mount namespace and not leak them).  A leaked mount point will block container upgrades since we won't be able to rm -rf its rootfs.