### PR TITLE
flannel: make /proc/fs and /proc/sys writeable

### DIFF
--- a/flannel/config.json.template
+++ b/flannel/config.json.template
@@ -193,9 +193,7 @@
 		"readonlyPaths": [
 			"/proc/asound",
 			"/proc/bus",
-			"/proc/fs",
 			"/proc/irq",
-			"/proc/sys",
 			"/proc/sysrq-trigger"
 		]
 	}


### PR DESCRIPTION
Flannel 0.7 seems to write here and would fail if it is read only.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>