### PR TITLE
Add labels to etcd and flannel

### DIFF
--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -2,6 +2,14 @@ FROM fedora
 
 MAINTAINER Giuseppe Scrivano <gscrivan@redhat.com>
 
+ENV VERSION=0.1 RELEASE=1 ARCH=x86_64
+LABEL BZComponent="etcd-docker" \
+      Name="$FGC/etcd" \
+      Version="$VERSION" \
+      Release="$RELEASE" \
+      Architecture="$ARCH" \
+      Summary="A key-value store for shared configuration and service discovery, intended to be run as a system container"
+
 RUN dnf -y install etcd hostname && \
     dnf clean all
 

--- a/flannel/Dockerfile
+++ b/flannel/Dockerfile
@@ -6,6 +6,14 @@ ENV container=docker
 ENV FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
 ENV FLANNELD_ETCD_PREFIX="/atomic.io/network"
 
+ENV VERSION=0.1 RELEASE=1 ARCH=x86_64
+LABEL BZComponent="flannel-docker" \
+      Name="$FGC/flannel" \
+      Version="$VERSION" \
+      Release="$RELEASE" \
+      Architecture="$ARCH" \
+      Summary="An etcd driven address agent, intended to be run as a system container"
+
 RUN dnf -y install flannel && dnf clean all
 
 ADD flanneld-run.sh /usr/bin/


### PR DESCRIPTION
Add initial labels to etcd and flannel with reference to the fedora
registry guidelines.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>