### PR TITLE
Fix Dockerfile and README for etcd/flannel

### DIFF
--- a/docker-centos/Dockerfile
+++ b/docker-centos/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos
-MAINTAINER Giuseppe Scrivano <gscrivan@redhat.com>
+
+LABEL Maintainer="Giuseppe Scrivano <gscrivan@redhat.com>"
 
 RUN yum install -y docker docker-latest container-selinux python-docker-py docker-lvm-plugin docker-rhel-push-plugin docker-novolume-plugin lvm2 iptables procps-ng xz cloud-utils-growpart && yum clean all
 ADD init.sh /usr/bin

--- a/docker-fedora/Dockerfile
+++ b/docker-fedora/Dockerfile
@@ -1,5 +1,6 @@
 FROM fedora:rawhide
-MAINTAINER Giuseppe Scrivano <gscrivan@redhat.com>
+
+LABEL Maintainer="Giuseppe Scrivano <gscrivan@redhat.com>"
 
 RUN dnf install -y docker container-selinux cloud-utils-growpart python-docker-py docker-novolume-plugin lvm2 iptables procps-ng xz inotify-tools && mkdir -p /usr/lib/modules && dnf clean all
 

--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM fedora:25
 
 MAINTAINER Giuseppe Scrivano <gscrivan@redhat.com>
 
@@ -8,9 +8,9 @@ LABEL BZComponent="etcd-docker" \
       Version="$VERSION" \
       Release="$RELEASE" \
       Architecture="$ARCH" \
-      Summary="A key-value store for shared configuration and service discovery, intended to be run as a system container"
+      Summary="A key-value store for shared configuration and service discovery."
 
-RUN dnf -y install etcd hostname && \
+RUN dnf -y --setopt=tsflags=nodocs install etcd hostname && \
     dnf clean all
 
 COPY etcd-env.sh /usr/bin/etcd-env.sh

--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -1,14 +1,13 @@
 FROM fedora:25
 
-MAINTAINER Giuseppe Scrivano <gscrivan@redhat.com>
-
 ENV VERSION=0.1 RELEASE=1 ARCH=x86_64
 LABEL BZComponent="etcd-docker" \
       Name="$FGC/etcd" \
       Version="$VERSION" \
       Release="$RELEASE" \
       Architecture="$ARCH" \
-      Summary="A key-value store for shared configuration and service discovery."
+      Summary="A key-value store for shared configuration and service discovery." \
+      Maintainer="Giuseppe Scrivano <gscrivan@redhat.com>"
 
 RUN dnf -y --setopt=tsflags=nodocs install etcd hostname && \
     dnf clean all

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -1,13 +1,16 @@
 # etcd-container
 
-Building etcd container for rhel, centos and atomic host:
+Building etcd container for fedora and atomic host:
 
 ```
-# git clone https://github.com/aveshagarwal/etcd-container
-# cd etcd-container
+# git clone https://github.com/projectatomic/atomic-system-containers
+# cd atomic-system-containers/etcd
 # docker build --rm -t etcd .
 ```
-**Instructions for RHEL and CentOS**
+
+## As a docker container:
+
+**Instructions for Fedora**
 
 Running etcd container
 
@@ -36,6 +39,38 @@ Stopping etcd container on atomic host:
 ```
 
 Uninstalling etcd container on atomic host:
+
+```
+#atomic uninstall etcd
+```
+
+## As a system container, with the atomic CLI:
+
+Pull from local docker into ostree:
+
+```
+#atomic pull --storage ostree docker:etcd
+```
+
+Install the container:
+
+```
+#atomic install --system etcd
+```
+
+Start as a systemd service:
+
+```
+#systemctl start etcd
+```
+
+Stopping the service
+
+```
+#systemctl stop etcd
+```
+
+Removing the container
 
 ```
 #atomic uninstall etcd

--- a/flannel/Dockerfile
+++ b/flannel/Dockerfile
@@ -1,10 +1,8 @@
-FROM fedora
+FROM fedora:25
 
 MAINTAINER Giuseppe Scrivano <gscrivan@redhat.com>
 
-ENV container=docker
-ENV FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
-ENV FLANNELD_ETCD_PREFIX="/atomic.io/network"
+ENV container=docker FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379" FLANNELD_ETCD_PREFIX="/atomic.io/network"
 
 ENV VERSION=0.1 RELEASE=1 ARCH=x86_64
 LABEL BZComponent="flannel-docker" \
@@ -15,7 +13,7 @@ LABEL BZComponent="flannel-docker" \
       Summary="An etcd driven address agent, intended to be run as a system container" \
       atomic.type='system'
 
-RUN dnf -y install flannel && dnf clean all
+RUN dnf -y --setopt=tsflags=nodocs install flannel && dnf clean all
 
 ADD flanneld-run.sh /usr/bin/
 

--- a/flannel/Dockerfile
+++ b/flannel/Dockerfile
@@ -1,7 +1,5 @@
 FROM fedora:25
 
-MAINTAINER Giuseppe Scrivano <gscrivan@redhat.com>
-
 ENV container=docker FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379" FLANNELD_ETCD_PREFIX="/atomic.io/network"
 
 ENV VERSION=0.1 RELEASE=1 ARCH=x86_64
@@ -11,6 +9,7 @@ LABEL BZComponent="flannel-docker" \
       Release="$RELEASE" \
       Architecture="$ARCH" \
       Summary="An etcd driven address agent, intended to be run as a system container" \
+      Maintainer="Giuseppe Scrivano <gscrivan@redhat.com>" \
       atomic.type='system'
 
 RUN dnf -y --setopt=tsflags=nodocs install flannel && dnf clean all

--- a/flannel/README.md
+++ b/flannel/README.md
@@ -19,7 +19,7 @@ Prerequisite:
 
 2. a network is configured in etcd
 
-(example with etcd also installed as a system container: `runc exec etcd etcdctl set /atomic.io/network/config '{"Network":"172.17.0.0/16"}'`)
+(example with etcd installed as a system container: `runc exec etcd etcdctl set /atomic.io/network/config '{"Network":"172.17.0.0/16"}'`)
 
 Pull from local docker into ostree:
 

--- a/flannel/README.md
+++ b/flannel/README.md
@@ -1,0 +1,52 @@
+# flannel-container
+
+This container image is intended to be run as a system container
+with the atomic command line.
+
+Building flannel container for fedora and atomic host:
+
+```
+# git clone https://github.com/projectatomic/atomic-system-containers
+# cd atomic-system-containers/flannel
+# docker build -t flannel .
+```
+
+**Running as system container, with the atomic CLI:**
+
+Prerequisite:
+
+1. etcd must be running
+
+2. a network is configured in etcd
+
+(example with etcd also installed as a system container: `runc exec etcd etcdctl set /atomic.io/network/config '{"Network":"172.17.0.0/16"}'`)
+
+Pull from local docker into ostree:
+
+```
+#atomic pull --storage ostree docker:flannel
+```
+
+Install the container:
+
+```
+#atomic install --system flannel
+```
+
+Start as a systemd service:
+
+```
+#systemctl start flannel
+```
+
+Stopping the service
+
+```
+#systemctl stop flannel
+```
+
+Removing the container
+
+```
+#atomic uninstall flannel
+```


### PR DESCRIPTION
In response to comments from bugzilla, add following changes:

1. Pin container to specific fedora version
2. Chain labels
3. Add/fix README
4. Install packages without docs

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>