### PR TITLE
More Dockerfile fixes

### DIFF
--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -1,10 +1,10 @@
-FROM fedora:25
+FROM fedora:rawhide
 
-ENV VERSION=0.1 RELEASE=1 ARCH=x86_64
-LABEL BZComponent="etcd-docker" \
+ENV VERSION=0.1 RELEASE=3 ARCH=x86_64
+LABEL BZComponent="etcd" \
       Name="$FGC/etcd" \
       Version="$VERSION" \
-      Release="$RELEASE" \
+      Release="$RELEASE.$DISTTAG" \
       Architecture="$ARCH" \
       Summary="A key-value store for shared configuration and service discovery." \
       maintainer="Giuseppe Scrivano <gscrivan@redhat.com>"

--- a/flannel/Dockerfile
+++ b/flannel/Dockerfile
@@ -1,12 +1,12 @@
-FROM fedora:25
+FROM fedora:rawhide
 
 ENV container=docker FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379" FLANNELD_ETCD_PREFIX="/atomic.io/network"
 
-ENV VERSION=0.1 RELEASE=1 ARCH=x86_64
-LABEL BZComponent="flannel-docker" \
+ENV VERSION=0.1 RELEASE=2 ARCH=x86_64
+LABEL BZComponent="flannel" \
       Name="$FGC/flannel" \
       Version="$VERSION" \
-      Release="$RELEASE" \
+      Release="$RELEASE.$DISTTAG" \
       Architecture="$ARCH" \
       Summary="An etcd driven address agent, intended to be run as a system container" \
       maintainer="Giuseppe Scrivano <gscrivan@redhat.com>" \


### PR DESCRIPTION
1. the BZComponent must match the container name
2. the master branch should be based off rawhide
3. the Release label should include disttag to differentiate in koji

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>