### PR TITLE
bind mount host resolv.conf

### DIFF
--- a/etcd/config.json.template
+++ b/etcd/config.json.template
@@ -155,7 +155,17 @@
 				"rw",
 				"mode=755"
 			]
-		}
+		},
+                {
+                        "destination": "/etc/resolv.conf",
+                        "type": "bind",
+                        "source": "/etc/resolv.conf",
+                        "options": [
+                                "ro",
+                                "rbind",
+                                "rprivate"
+                        ]
+        }
 	],
 	"linux": {
 		"capabilities": [


### PR DESCRIPTION
Same idea as #14 -- in order to use the container's etcdctl to configure etcd at a particular hostname, the etcd container needs to be able to resolve hostnames properly.