### PR TITLE
flannel: make /sys/fs not writeable

### DIFF
--- a/flannel/config.json.template
+++ b/flannel/config.json.template
@@ -203,6 +203,7 @@
 		"readonlyPaths": [
 			"/proc/asound",
 			"/proc/bus",
+			"/proc/fs",
 			"/proc/irq",
 			"/proc/sysrq-trigger"
 		]


### PR DESCRIPTION
It seems that it is not needed to be writeable as /proc/sys is enough to
get vxlan working.

Reverts part of commit eb5a4794b4c0090402d6d8e804356ace15dcf7cb

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>