### PR TITLE
Docker add AUDIT_READ as well

### DIFF
--- a/docker-centos/config.json.template
+++ b/docker-centos/config.json.template
@@ -56,7 +56,8 @@
             "CAP_MAC_ADMIN",
             "CAP_SYSLOG",
             "CAP_WAKE_ALARM",
-            "CAP_BLOCK_SUSPEND"
+            "CAP_BLOCK_SUSPEND",
+            "CAP_AUDIT_READ"
 	],
 	"noNewPrivileges": false
     },

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -56,7 +56,8 @@
             "CAP_MAC_ADMIN",
             "CAP_SYSLOG",
             "CAP_WAKE_ALARM",
-            "CAP_BLOCK_SUSPEND"
+            "CAP_BLOCK_SUSPEND",
+            "CAP_AUDIT_READ"
 	],
 	"noNewPrivileges": false
     },


### PR DESCRIPTION
I thought `AUDIT_READ` would never be needed by Docker but I forgot of the `--privileged` case.