### PR TITLE
Revert CAP_AUDIT_READ from Docker Centos

### DIFF
--- a/docker-centos/config.json.template
+++ b/docker-centos/config.json.template
@@ -56,8 +56,7 @@
             "CAP_MAC_ADMIN",
             "CAP_SYSLOG",
             "CAP_WAKE_ALARM",
-            "CAP_BLOCK_SUSPEND",
-            "CAP_AUDIT_READ"
+            "CAP_BLOCK_SUSPEND"
 	],
 	"noNewPrivileges": false
     },

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -16,7 +16,7 @@
 	"env": [
 	    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	    "TERM=xterm",
-            "NAME=docker"
+            "NAME=$NAME"
 	],
 	"cwd": "/",
 	"capabilities": [


### PR DESCRIPTION
the cap is not available there so drop it.

Given the differences between Fedora and CentOS/RHEL, from now on we must make clear that docker-centos is based on CentOS and it is the version to use on CentOS/RHEL.

Differently on Fedora docker-fedora must be used.