### PR TITLE
Fix labels for etcd and flannel

### DIFF
--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -1,12 +1,12 @@
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide
 
-ENV VERSION=0.1 RELEASE=3 ARCH=x86_64
-LABEL BZComponent="etcd" \
-      Name="$FGC/etcd" \
-      Version="$VERSION" \
-      Release="$RELEASE.$DISTTAG" \
-      Architecture="$ARCH" \
-      Summary="A key-value store for shared configuration and service discovery." \
+ENV VERSION=0.1 RELEASE=10 ARCH=x86_64
+LABEL com.redhat.component="etcd" \
+      name="$FGC/etcd" \
+      version="$VERSION" \
+      release="$RELEASE.$DISTTAG" \
+      architecture="$ARCH" \
+      summary="A key-value store for shared configuration and service discovery." \
       maintainer="Giuseppe Scrivano <gscrivan@redhat.com>"
 
 RUN dnf -y --setopt=tsflags=nodocs install etcd hostname && \

--- a/flannel/Dockerfile
+++ b/flannel/Dockerfile
@@ -1,14 +1,14 @@
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide
 
 ENV container=docker FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379" FLANNELD_ETCD_PREFIX="/atomic.io/network"
 
-ENV VERSION=0.1 RELEASE=2 ARCH=x86_64
-LABEL BZComponent="flannel" \
-      Name="$FGC/flannel" \
-      Version="$VERSION" \
-      Release="$RELEASE.$DISTTAG" \
-      Architecture="$ARCH" \
-      Summary="An etcd driven address agent, intended to be run as a system container" \
+ENV VERSION=0.1 RELEASE=8 ARCH=x86_64
+LABEL com.redhat.component="flannel" \
+      name="$FGC/flannel" \
+      version="$VERSION" \
+      release="$RELEASE.$DISTTAG" \
+      architecture="$ARCH" \
+      summary="An etcd driven address agent, intended to be run as a system container" \
       maintainer="Giuseppe Scrivano <gscrivan@redhat.com>" \
       atomic.type='system'
 


### PR DESCRIPTION
Change labels to lowercase, as decided by the fedora container
guidelines discussion. Also use fqn for the base image.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>