### PR TITLE
Remove use of sysconfig docker from containers

### DIFF
--- a/docker-centos/service.template
+++ b/docker-centos/service.template
@@ -3,7 +3,6 @@ Description=Docker service
 After=network.target
 
 [Service]
-EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/sysconfig/docker-network
 Environment=GOTRACEBACK=crash

--- a/docker-fedora/service.template
+++ b/docker-fedora/service.template
@@ -3,7 +3,6 @@ Description=Docker service
 After=network.target
 
 [Service]
-EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/sysconfig/docker-network
 Environment=GOTRACEBACK=crash


### PR DESCRIPTION
- Move /etc/sysconfig/docker to /etc/sysconfig/docker.orig
- Add a note in /etc/sysconfig/docker.orig pointing to daemon.json
- Remove /etc/sysconfig/docker from systemd templates

Related to https://github.com/openshift/openshift-ansible/pull/4106#discussion_r115111843