### PR TITLE
Prepare docker-fedora for fedora registry

### DIFF
--- a/docker-fedora/Dockerfile
+++ b/docker-fedora/Dockerfile
@@ -1,10 +1,15 @@
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide
 
-LABEL maintainer="Giuseppe Scrivano <gscrivan@redhat.com>" \
-      name="docker-fedora" \
-      version="0.1" \
-      atomic.type="system" \
-      architecture="x86_64"
+ENV VERSION=0.1 RELEASE=1 ARCH=x86_64
+LABEL com.redhat.component="container-engine" \
+      name="$FGC/container-engine" \
+      version="$VERSION" \
+      release="$RELEASE.$DISTTAG" \
+      architecture="$ARCH" \
+      usage="atomic install --system --system-package=no container-engine && systemctl start container-engine"
+      summary="The docker container engine as a system container." \
+      maintainer="Giuseppe Scrivano <gscrivan@redhat.com>" \
+      atomic.type="system"
 
 RUN dnf install --setopt=tsflags=nodocs -y docker container-selinux cloud-utils-growpart python-docker-py docker-novolume-plugin lvm2 iptables procps-ng xz oci-register-machine \
     && rpm -V docker container-selinux cloud-utils-growpart python-docker-py docker-novolume-plugin lvm2 iptables procps-ng xz oci-register-machine \

--- a/docker-fedora/README.md
+++ b/docker-fedora/README.md
@@ -1,0 +1,58 @@
+# container-engine
+
+This is the container engine system container for fedora systems based on the moby project.
+For more information refer to: https://github.com/moby/moby
+
+Note this only provides the *daemon process*, and does not include CLI tools. The current use
+case for this would be switching between different versions of the engine by updating the
+container.
+
+## Building the image from source:
+
+```
+# git clone https://github.com/projectatomic/atomic-system-containers
+# cd atomic-system-containers/docker-fedora
+# docker build -t container-engine .
+```
+
+## Running the system container, with the atomic CLI:
+
+Pull from registry into ostree:
+
+```
+# atomic pull --storage ostree $REGISTRY/container-engine
+```
+
+Or alternatively, pull from local docker:
+
+```
+# atomic pull --storage ostree docker:container-engine:latest
+```
+
+Install the container:
+
+Currently we recommend using --system-package=no to avoid having rpmbuild create an rpm file
+during installation. This flag will tell the atomic CLI to fall back to copying files to the
+host instead.
+
+```
+# atomic install --system --system-package=no --name=container-engine ($REGISTRY)/container-engine
+```
+
+Start as a systemd service:
+
+```
+# systemctl start container-engine
+```
+
+Stopping the service
+
+```
+# systemctl stop container-engine
+```
+
+Removing the container
+
+```
+# atomic uninstall container-engine
+```


### PR DESCRIPTION
Add proper labels and README for docker-fedora image, intended to
be built into the fedora registry as "container-engine" system
container.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>