### PR TITLE
docker containers: Add /var/run for secrets

### DIFF
--- a/docker-centos/config.json.template
+++ b/docker-centos/config.json.template
@@ -311,6 +311,17 @@
 		"mode=755"
 	    ]
 	},
+	{
+	    "type": "bind",
+	    "source": "/var/run",
+	    "destination": "/var/run",
+	    "options": [
+		"rshared",
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+	},
         {
             "type": "bind",
             "source": "/var/log",

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -316,6 +316,17 @@
 		"mode=755"
 	    ]
 	},
+	{
+	    "type": "bind",
+	    "source": "/var/run",
+	    "destination": "/var/run",
+	    "options": [
+		"rshared",
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+	},
         {
             "type": "bind",
             "source": "/var/log",


### PR DESCRIPTION
Mount /var/run into the container as rw so secrets can be read.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1450286