### PR TITLE
docker: use systemd-notify

### DIFF
--- a/docker-centos/init.sh
+++ b/docker-centos/init.sh
@@ -18,7 +18,7 @@ do
     $i &
 done
 
-/usr/bin/docker-containerd-current \
+NOTIFY_SOCKET=/dev/null /usr/bin/docker-containerd-current \
     --listen unix:///run/containerd.sock \
     --shim /usr/bin/docker-containerd-shim-current \
     --start-timeout 2m &

--- a/docker-centos/init.sh
+++ b/docker-centos/init.sh
@@ -18,6 +18,8 @@ do
     $i &
 done
 
+# Inhibit sd-notify for docker-containerd, we want to get the notification
+# from the docker process
 NOTIFY_SOCKET=/dev/null /usr/bin/docker-containerd-current \
     --listen unix:///run/containerd.sock \
     --shim /usr/bin/docker-containerd-shim-current \

--- a/docker-centos/service.template
+++ b/docker-centos/service.template
@@ -16,6 +16,8 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
 TimeoutStartSec=0
+Type=notify
+NotifyAccess=all
 
 [Install]
 WantedBy=multi-user.target

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -316,6 +316,17 @@
 		"mode=755"
 	    ]
 	},
+	{
+            "type": "bind",
+            "source": "/run/systemd",
+            "destination": "/run/systemd",
+            "options": [
+                "rslave",
+                "bind",
+                "rw",
+                "mode=755"
+            ]
+	},
         {
             "type": "bind",
             "source": "/var/log",

--- a/docker-fedora/init.sh
+++ b/docker-fedora/init.sh
@@ -10,6 +10,9 @@ source /run/docker-bash-env
 
 getent group docker || groupadd docker
 
+
+# Inhibit sd-notify for docker-containerd, we want to get the notification
+# from the docker process
 NOTIFY_SOCKET=/dev/null /usr/libexec/docker/docker-containerd-current \
     --listen unix:///run/containerd.sock      \
     --shim /usr/bin/shim.sh &

--- a/docker-fedora/init.sh
+++ b/docker-fedora/init.sh
@@ -10,7 +10,7 @@ source /run/docker-bash-env
 
 getent group docker || groupadd docker
 
-/usr/libexec/docker/docker-containerd-current \
+NOTIFY_SOCKET=/dev/null /usr/libexec/docker/docker-containerd-current \
     --listen unix:///run/containerd.sock      \
     --shim /usr/bin/shim.sh &
 

--- a/docker-fedora/service.template
+++ b/docker-fedora/service.template
@@ -16,6 +16,8 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
 TimeoutStartSec=0
+Type=notify
+NotifyAccess=all
 
 [Install]
 WantedBy=multi-user.target

--- a/docker-fedora/set_mounts.sh
+++ b/docker-fedora/set_mounts.sh
@@ -2,3 +2,4 @@
 
 findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
 mount --make-shared /run
+findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd


### PR DESCRIPTION
Since newer runC have this feature, take advantage of it to properly report when the service is ready