### PR TITLE
doc: Add FILES.md with blurbs about expected files

### DIFF
--- a/FILES.md
+++ b/FILES.md
@@ -1,0 +1,39 @@
+# Files for System Containers
+
+## Required
+
+These files must be present to be considered a valid system image.
+
+### config.json.template
+
+This file used by runc and describes the container configuration. It defines mounts, capabilities, process options, etc.
+
+For more information see [the oci config documentation](https://github.com/opencontainers/runtime-spec/blob/master/config.md).
+
+Example: [hello-world/config.json.template](hello-world/config.json.template)
+
+### service.template
+
+This file is used when creating a systemd service upon system container installation.
+
+For more information see [systemd unit documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html).
+
+Example: [hello-world/service.template](hello-world/service.template)
+
+## Optional
+
+The following files may be omitted if their additional features are not required.
+
+### manifest.json
+
+Defines default values for variables used within the system image. Variables may be referenced in other system image files.
+
+Example: [hello-world/manifest.json](hello-world/manifest.json)
+
+### tmpfiles.template
+
+Defines file/location creation, deletion, and purge operations for temporary storage.
+
+For more information see [systemd tmpfiles.d documentation](https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html).
+
+Example: [docker-fedora/tmpfiles.template](docker-fedora/tmpfiles.template)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ System containers use different technologies:
  * We use the [atomic](https://github.com/projectatomic/atomic) tool to install
  system containers.
  * [Labels](LABELS.md) can influence how the *atomic tool* uses a system container
+ * Specific [files](FILES.md) are required to be part of a valid system image
  * For storage system containers do not need to use COW File systems, since
  they are in production. We default to using OSTree for storage of the
  container images.


### PR DESCRIPTION
FILES.md adds quick information on files that must be present for an
image to be considered a system image. The doc file also contains
information on optional files as well as links out to various locations
for more information.