### PR TITLE
Rename daemon.json to container-daemon.json

### DIFF
--- a/docker-centos/Dockerfile
+++ b/docker-centos/Dockerfile
@@ -20,6 +20,6 @@ ADD init.sh /usr/bin
 
 # system container
 COPY service.template tmpfiles.template config.json.template /exports/
-COPY daemon.json /exports/hostfs/etc/docker/
+COPY daemon.json /exports/hostfs/etc/docker/container-daemon.json
 
 CMD ["/usr/bin/init.sh"]

--- a/docker-centos/init.sh
+++ b/docker-centos/init.sh
@@ -31,7 +31,7 @@ do
 done
 
 exec /usr/bin/docker-current daemon \
-          --config-file=/etc/docker/daemon.json \
+          --config-file=/etc/docker/container-daemon.json \
           --userland-proxy-path=/usr/libexec/docker/docker-proxy-current \
           $OPTIONS \
           $DOCKER_STORAGE_OPTIONS \

--- a/docker-fedora/Dockerfile
+++ b/docker-fedora/Dockerfile
@@ -22,6 +22,6 @@ COPY shim.sh init.sh /usr/bin/
 # system container
 COPY set_mounts.sh /
 COPY config.json.template service.template tmpfiles.template /exports/
-COPY daemon.json /exports/hostfs/etc/docker/
+COPY daemon.json /exports/hostfs/etc/docker/container-daemon.json
 
 CMD ["/usr/bin/init.sh"]

--- a/docker-fedora/init.sh
+++ b/docker-fedora/init.sh
@@ -33,7 +33,7 @@ do
 done
 
 exec /usr/bin/dockerd-current \
-     --config-file=/etc/docker/daemon.json \
+     --config-file=/etc/docker/container-daemon.json \
      $OPTIONS \
      $DOCKER_STORAGE_OPTIONS \
      $DOCKER_NETWORK_OPTIONS \


### PR DESCRIPTION
Renames ``daemon.json`` to ``container-daemon.json`` to keep all containers using the same location.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1448384#c24