### PR TITLE
docker-fedora: Drop default /etc/oci-umount.conf

### DIFF
--- a/docker-fedora/Dockerfile
+++ b/docker-fedora/Dockerfile
@@ -23,5 +23,7 @@ COPY shim.sh init.sh /usr/bin/
 COPY set_mounts.sh /
 COPY config.json.template service.template tmpfiles.template /exports/
 COPY daemon.json /exports/hostfs/etc/docker/container-daemon.json
+# https://github.com/rhatdan/oci-umount/issues/2
+COPY oci-umount.conf /exports/hostfs/etc/oci-umount.conf
 
 CMD ["/usr/bin/init.sh"]


### PR DESCRIPTION
This change drops an empty ```/etc/oci-umount.conf``` if the host doesn't
exist on the host. This is to avoid ```oci-umount``` raising an error and
keeping containers from running.

Ref: https://github.com/rhatdan/oci-umount/issues/2