### PR TITLE
docker-fedora: /etc/oci-umount.conf is now required

### DIFF
--- a/docker-fedora/Dockerfile
+++ b/docker-fedora/Dockerfile
@@ -24,6 +24,6 @@ COPY set_mounts.sh /
 COPY config.json.template service.template tmpfiles.template /exports/
 COPY daemon.json /exports/hostfs/etc/docker/container-daemon.json
 # https://github.com/rhatdan/oci-umount/issues/2
-COPY oci-umount.conf /exports/hostfs/etc/oci-umount.conf
+RUN cp /etc/oci-umount.conf /exports/hostfs/etc
 
 CMD ["/usr/bin/init.sh"]


### PR DESCRIPTION
This file is now required for docker to start. The contents have been
updated to reflect upstream.

Ref: https://github.com/projectatomic/oci-umount/blob/master/oci-umount.conf