### PR TITLE
SELinuxContext for docker container unit files

### DIFF
--- a/docker-centos/service.template
+++ b/docker-centos/service.template
@@ -6,6 +6,7 @@ After=network.target
 EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/sysconfig/docker-network
 Environment=GOTRACEBACK=crash
+SELinuxContext=system_u:system_r:container_runtime_t:s0
 ExecStartPre=/bin/bash -c 'export -p > /run/docker-bash-env'
 ExecStart=$EXEC_START
 ExecStop=$EXEC_STOP

--- a/docker-fedora/service.template
+++ b/docker-fedora/service.template
@@ -6,6 +6,7 @@ After=network.target
 EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/sysconfig/docker-network
 Environment=GOTRACEBACK=crash
+SELinuxContext=system_u:system_r:container_runtime_t:s0
 ExecStartPre=/bin/sh $DESTDIR/rootfs/set_mounts.sh
 ExecStartPre=/bin/bash -c 'export -p > /run/docker-bash-env'
 ExecStart=$EXEC_START


### PR DESCRIPTION
Add ``SELinuxContext=system_u:system_r:container_runtime_t:s0`` to both CentOS and Fedora unit files.