### PR TITLE
Minor fixes for fedora

### DIFF
--- a/docker-fedora/Dockerfile
+++ b/docker-fedora/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.fedoraproject.org/fedora:rawhide
 
 ENV VERSION=0 RELEASE=1 ARCH=x86_64
 LABEL com.redhat.component="docker" \
-      name="docker" \
+      name="$FGC/docker" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \

--- a/docker-fedora/daemon.json
+++ b/docker-fedora/daemon.json
@@ -1,6 +1,4 @@
-
 {
-    "authorization-plugins": ["rhel-push-plugin"],
     "default-runtime": "oci",
     "containerd": "/run/containerd.sock",
     "userland-proxy-path": "/usr/libexec/docker/docker-proxy-current",


### PR DESCRIPTION
Use $FGC in "name" label for the fedora registry. Also remove RHEL
plugin.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>