### PR TITLE
etcd: check if etcd.conf exists before reading it

### DIFF
--- a/etcd/etcd-env.sh
+++ b/etcd/etcd-env.sh
@@ -7,7 +7,9 @@ fi
 export ETCD_NAME=${ETCD_NAME:-$HOSTNAME}
 export ETCD_DATA_DIR=/var/lib/etcd/${NAME}.etcd
 
-source /etc/etcd/etcd.conf
+if test -e /etc/etcd/etcd.conf; then
+    source /etc/etcd/etcd.conf
+fi
 
 # Execute the commands passed to this script
 exec "$@"


### PR DESCRIPTION
user containers do not copy files to the host.  Check if the file
exists before attempting to read it.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>