### PR TITLE
Create cri-o system container

### DIFF
--- a/cri-o/Dockerfile
+++ b/cri-o/Dockerfile
@@ -1,0 +1,24 @@
+FROM registry.fedoraproject.org/fedora:25
+
+ENV VERSION=0 RELEASE=1 ARCH=x86_64
+LABEL com.redhat.component="cri-o" \
+      name="$FGC/cri-o" \
+      version="$VERSION" \
+      release="$RELEASE.$DISTTAG" \
+      architecture="$ARCH" \
+      usage="atomic install --system --system-package=no crio && systemctl start crio" \
+      summary="The cri-o daemon as a system container." \
+      maintainer="Yu Qi Zhang <jzehrarnyg@gmail.com>" \
+      atomic.type="system"
+
+RUN dnf -y --setopt=tsflags=nodocs install btrfs-progs-devel device-mapper-devel glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel libgpg-error-devel libseccomp-devel libselinux-devel \
+    pkgconfig runc wget git findutils gcc iptables skopeo && \
+    dnf clean all
+
+COPY tmpfiles.template config.json.template service.template /exports/
+
+COPY build.sh run.sh /usr/bin/
+
+RUN /usr/bin/build.sh
+
+CMD ["/usr/bin/run.sh"]

--- a/cri-o/Dockerfile
+++ b/cri-o/Dockerfile
@@ -11,10 +11,6 @@ LABEL com.redhat.component="cri-o" \
       maintainer="Yu Qi Zhang <jzehrarnyg@gmail.com>" \
       atomic.type="system"
 
-RUN dnf -y --setopt=tsflags=nodocs install btrfs-progs-devel device-mapper-devel glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel libgpg-error-devel libseccomp-devel libselinux-devel \
-    pkgconfig runc wget git findutils gcc iptables skopeo && \
-    dnf clean all
-
 COPY tmpfiles.template config.json.template service.template /exports/
 
 COPY build.sh run.sh /usr/bin/

--- a/cri-o/README.md
+++ b/cri-o/README.md
@@ -1,0 +1,62 @@
+# cri-o
+
+This is the cri-o daemon as a system container. Currently this is only
+in the experimental stage, and cri-o is being build from source inside
+the container, causing the image to be quite large.
+
+This container currently provides crioctl on the host once installed,
+but does not include cni configs. The daemon will run as is, but to
+run pods and containers, you must set up cni plugins as shown in:
+https://github.com/kubernetes-incubator/cri-o/blob/master/tutorial.md
+
+
+## Building the image from source:
+
+```
+# git clone https://github.com/projectatomic/atomic-system-containers
+# cd atomic-system-containers/cri-o
+# docker build -t crio .
+```
+
+## Running the system container, with the atomic CLI:
+
+Pull from registry into ostree:
+
+```
+# atomic pull --storage ostree $REGISTRY/crio
+```
+
+Or alternatively, pull from local docker:
+
+```
+# atomic pull --storage ostree docker:crio:latest
+```
+
+Install the container:
+
+Currently we recommend using --system-package=no to avoid having rpmbuild create an rpm file
+during installation. This flag will tell the atomic CLI to fall back to copying files to the
+host instead.
+
+```
+# atomic install --system --system-package=no --name=crio ($REGISTRY)/crio
+```
+
+Start as a systemd service:
+
+```
+# systemctl start crio
+```
+
+Stopping the service
+
+```
+# systemctl stop crio
+```
+
+Removing the container
+
+```
+# atomic uninstall crio
+```
+

--- a/cri-o/build.sh
+++ b/cri-o/build.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 
+dnf -y --setopt=tsflags=nodocs install btrfs-progs-devel device-mapper-devel glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel libgpg-error-devel libseccomp-devel libselinux-devel \
+pkgconfig runc wget git findutils gcc iptables skopeo
+
 export GOPATH=/root/go && export PATH=$PATH:/usr/local/go/bin:/root/go/bin
 
 mkdir -p /root/go/src
 
 wget https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz && tar -xvf go1.7.4.linux-amd64.tar.gz -C /usr/local/
+
+rm -f go1.7.4.linux-amd64.tar.gz
 
 go get -d github.com/kubernetes-incubator/cri-o
 
@@ -17,3 +22,11 @@ cp $GOPATH/src/github.com/kubernetes-incubator/cri-o/crioctl /usr/bin/
 mkdir -p /exports/hostfs/usr/bin && cp /usr/bin/crioctl /exports/hostfs/usr/bin/crioctl
 
 mkdir -p /exports/hostfs/etc/ && cp -r /etc/crio/ /exports/hostfs/etc/crio/
+
+rm -rf /usr/local/go
+
+rm -rf $GOPATH
+
+dnf remove -y btrfs-progs-devel device-mapper-devel glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel libgpg-error-devel libseccomp-devel libselinux-devel \
+pkgconfig wget git findutils gcc && \
+dnf clean all

--- a/cri-o/build.sh
+++ b/cri-o/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+export GOPATH=/root/go && export PATH=$PATH:/usr/local/go/bin:/root/go/bin
+
+mkdir -p /root/go/src
+
+wget https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz && tar -xvf go1.7.4.linux-amd64.tar.gz -C /usr/local/
+
+go get -d github.com/kubernetes-incubator/cri-o
+
+cd $GOPATH/src/github.com/kubernetes-incubator/cri-o
+
+make install.tools && make && make install && make install.config
+
+cp $GOPATH/src/github.com/kubernetes-incubator/cri-o/crioctl /usr/bin/
+
+mkdir -p /exports/hostfs/usr/bin && cp /usr/bin/crioctl /exports/hostfs/usr/bin/crioctl
+
+mkdir -p /exports/hostfs/etc/ && cp -r /etc/crio/ /exports/hostfs/etc/crio/

--- a/cri-o/config.json.template
+++ b/cri-o/config.json.template
@@ -1,0 +1,400 @@
+{
+    "hooks": {},
+    "linux": {
+        "namespaces": [
+            {
+                "type": "mount"
+            }
+        ],
+        "resources": {
+            "devices": [
+                {
+                    "access": "rwm",
+                    "allow": true
+                }
+            ]
+        },
+        "rootfsPropagation": "private",
+        "selinuxProcessLabel": "system_u:system_r:container_runtime_t:s0"
+    },
+    "mounts": [
+        {
+            "destination": "/tmp",
+            "options": [
+                "private",
+                "bind",
+                "rw",
+                "mode=755"
+            ],
+            "source": "/tmp",
+            "type": "bind"
+        },
+        {
+            "destination": "/etc",
+            "options": [
+                "rbind",
+                "rprivate",
+                "rw",
+                "mode=755"
+            ],
+            "source": "/etc",
+            "type": "bind"
+        },
+        {
+            "destination": "/lib/modules",
+            "options": [
+                "rbind",
+                "rprivate",
+                "rw",
+                "mode=755"
+            ],
+            "source": "/lib/modules",
+            "type": "bind"
+        },
+        {
+            "destination": "/root",
+            "options": [
+                "rbind",
+                "rprivate",
+                "rw",
+                "mode=755"
+            ],
+            "source": "/root",
+            "type": "bind"
+        },
+        {
+            "destination": "/home",
+            "options": [
+                "rbind",
+                "rprivate",
+                "rw",
+                "mode=755"
+            ],
+            "source": "/home",
+            "type": "bind"
+        },
+        {
+            "destination": "/mnt",
+            "options": [
+                "rbind",
+                "rw",
+                "rprivate",
+                "mode=755"
+            ],
+            "source": "/mnt",
+            "type": "bind"
+        },
+        {
+            "destination": "/run",
+            "options": [
+                "rshared",
+                "rbind",
+                "rw",
+                "mode=755"
+            ],
+            "source": "${RUN_DIRECTORY}",
+            "type": "bind"
+        },
+        {
+            "destination": "/run/systemd",
+            "options": [
+                "rslave",
+                "bind",
+                "rw",
+                "mode=755"
+            ],
+            "source": "/run/systemd",
+            "type": "bind"
+        },
+        {
+            "destination": "/var/log",
+            "options": [
+                "rbind",
+                "rslave",
+                "rw"
+            ],
+            "source": "/var/log",
+            "type": "bind"
+        },
+        {
+            "destination": "/var/lib",
+            "options": [
+                "rbind",
+                "rshared",
+                "rw"
+            ],
+            "source": "${STATE_DIRECTORY}",
+            "type": "bind"
+        },
+        {
+            "destination": "/dev",
+            "options": [
+                "rprivate",
+                "rbind",
+                "rw",
+                "mode=755"
+            ],
+            "source": "/dev",
+            "type": "bind"
+        },
+        {
+            "destination": "/sys",
+            "options": [
+                "rprivate",
+                "rbind",
+                "rw",
+                "mode=755"
+            ],
+            "source": "/sys",
+            "type": "bind"
+        },
+        {
+            "destination": "/proc",
+            "options": [
+                "private"
+            ],
+            "source": "/proc",
+            "type": "proc"
+        },
+        {
+            "destination": "/opt/cni",
+            "options": [
+                "rbind",
+                "rprivate",
+                "rw",
+                "mode=755"
+            ],
+            "source": "/opt/cni",
+            "type": "bind"
+        }
+    ],
+    "ociVersion": "1.0.0",
+    "platform": {
+        "arch": "amd64",
+        "os": "linux"
+    },
+    "process": {
+        "args": [
+            "/usr/bin/run.sh"
+        ],
+        "capabilities": {
+            "ambient": [
+                "CAP_CHOWN",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_DAC_OVERRIDE",
+                "CAP_MAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND",
+                "CAP_AUDIT_READ"
+            ],
+            "bounding": [
+                "CAP_CHOWN",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_DAC_OVERRIDE",
+                "CAP_MAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND",
+                "CAP_AUDIT_READ"
+            ],
+            "effective": [
+                "CAP_CHOWN",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_DAC_OVERRIDE",
+                "CAP_MAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND",
+                "CAP_AUDIT_READ"
+            ],
+            "inheritable": [
+                "CAP_CHOWN",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_DAC_OVERRIDE",
+                "CAP_MAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND",
+                "CAP_AUDIT_READ"
+            ],
+            "permitted": [
+                "CAP_CHOWN",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_DAC_OVERRIDE",
+                "CAP_MAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND",
+                "CAP_AUDIT_READ"
+            ]
+        },
+        "cwd": "/",
+        "env": [
+            "GOPATH=/root/go",
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/root/go/bin",
+            "TERM=xterm",
+            "NAME=$NAME"
+        ],
+        "noNewPrivileges": false,
+        "terminal": false,
+        "user": {
+            "gid": 0,
+            "uid": 0
+        }
+    },
+    "root": {
+        "path": "rootfs",
+        "readonly": true
+    }
+}

--- a/cri-o/run.sh
+++ b/cri-o/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/crio --debug

--- a/cri-o/service.template
+++ b/cri-o/service.template
@@ -1,0 +1,13 @@
+[Unit]
+Description=crio daemon
+After=network.target
+
+[Service]
+ExecStart=$EXEC_START
+ExecStop=$EXEC_STOP
+Restart=on-failure
+WorkingDirectory=$DESTDIR
+RuntimeDirectory=${NAME}
+
+[Install]
+WantedBy=multi-user.target

--- a/cri-o/tmpfiles.template
+++ b/cri-o/tmpfiles.template
@@ -1,0 +1,4 @@
+d    ${RUN_DIRECTORY}/${NAME}               -        -           -       - -
+d    /etc/crio - - - - -
+Z    /etc/crio - - - - -
+d    /opt/cni  - - - - -


### PR DESCRIPTION
Create a system container for cri-o, built from source inside the
container. Currently this is still experimental, but has been
tested to work on f25/26. In the future the build script will
likely be replaced by the packaged version.

The container image comes with crioctl installed on the host, but
does not include cni configs. The daemon will run, but to create
pods/containers, the user must still set up cni configs on the host.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>