### PR TITLE
Mount /dev from host to allow block storage support

### DIFF
--- a/kubernetes-kubelet/Dockerfile
+++ b/kubernetes-kubelet/Dockerfile
@@ -12,7 +12,7 @@ LABEL bzcomponent="$NAME" \
         atomic.type='system'
 
 # Containerized kubelet requires nsenter
-RUN dnf install -y util-linux ethtool && dnf clean all
+RUN dnf install -y util-linux ethtool systemd-udev e2fsprogs xfsprogs && dnf clean all
 
 LABEL RUN /usr/bin/docker run -d --privileged --net=host --pid=host -v /:/rootfs:ro -v /sys:/sys:rw -v /var/run:/var/run:rw -v /run:/run:rw -v /var/lib/docker:/var/lib/docker:rw -v /var/lib/kubelet:/var/lib/kubelet:slave -v /var/log/containers:/var/log/containers:rw
 

--- a/kubernetes-kubelet/config.json.template
+++ b/kubernetes-kubelet/config.json.template
@@ -232,14 +232,12 @@
             "source": "proc"
         },
         {
+            "source": "/dev",
             "destination": "/dev",
-            "type": "tmpfs",
-            "source": "tmpfs",
+            "type": "bind",
             "options": [
-                "nosuid",
-                "strictatime",
-                "mode=755",
-                "size=65536k"
+                "rbind",
+                "rslave"
             ]
         },
         {
@@ -265,16 +263,6 @@
                 "nodev",
                 "mode=1777",
                 "size=65536k"
-            ]
-        },
-        {
-            "destination": "/dev/mqueue",
-            "type": "mqueue",
-            "source": "mqueue",
-            "options": [
-                "nosuid",
-                "noexec",
-                "nodev"
             ]
         },
         {
@@ -386,7 +374,7 @@
         "resources": {
             "devices": [
                 {
-                    "allow": false,
+                    "allow": true,
                     "access": "rwm"
                 }
             ]


### PR DESCRIPTION
We need access to disk in dev. We also need some basic tools for formatting.
Mounting mqueue is not working I get a busy error that I couldn't solve.
I don't think we care that much since we are sharing the host IPC namespace anyway.