### PR TITLE
bind mount /run for iptables-restore

### DIFF
--- a/kubernetes-proxy/config.json.template
+++ b/kubernetes-proxy/config.json.template
@@ -320,6 +320,16 @@
                 "rbind",
                 "rprivate"
              ]
+          },
+          {
+            "type": "bind",
+            "source": "/run",
+            "destination": "/run",
+            "options": [
+                "rbind",
+                "rw",
+                "mode=755"
+             ]
           }
     ],
     "linux": {


### PR DESCRIPTION
Resolves issue found with kube 1.7.1: Failed to execute iptables-restore: failed to open iptables lock /run/xtables.lock: open /run/xtables.lock: read-only file system