### PR TITLE
ci: rename file and bump to f26

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -1,5 +1,5 @@
 container:
-    image: fedora:25
+  image: registry.fedoraproject.org/fedora:26
 
 packages:
     - python


### PR DESCRIPTION
Rename YAML file to the new name, and use the F26 container from the
Fedora registry for tests.