### PR TITLE
kubeadm system container

### DIFF
--- a/kubeadm/Dockerfile
+++ b/kubeadm/Dockerfile
@@ -1,0 +1,29 @@
+FROM registry.fedoraproject.org/fedora:rawhide
+
+ENV NAME=kubeadm VERSION=0 RELEASE=0 ARCH=x86_64
+LABEL   bzcomponent="$NAME" \
+        name="$FGC/$NAME" \
+        version="$VERSION" \
+        release="$RELEASE.$DISTTAG" \
+        architecture="$ARCH" \
+        atomic.type="system" \
+        maintainer="Jason Brooks <jbrooks@redhat.com>"
+
+RUN dnf install -y --setopt=tsflags=nodocs docker iproute kubernetes-kubeadm kubernetes-node kubernetes-client containernetworking-cni ethtool ebtables && dnf clean all
+
+LABEL RUN /usr/bin/docker run -d --privileged --net=host --pid=host -v /:/rootfs:ro -v /sys:/sys:rw -v /var/run:/var/run:rw -v /run:/run:rw -v /var/lib/docker:/var/lib/docker:rw -v /var/lib/kubelet:/var/lib/kubelet:slave -v /var/log/containers:/var/log/containers:rw
+
+COPY launch.sh /usr/bin/
+
+COPY service.template config.json.template /exports/
+
+RUN mkdir -p /exports/hostfs/usr/local/bin/ && cp /usr/bin/{kubectl,kubeadm} /exports/hostfs/usr/local/bin/
+RUN mkdir -p /exports/hostfs/etc/{kubernetes,cni}
+RUN mkdir -p /exports/hostfs/etc/kubernetes/pki
+RUN mkdir -p /var/lib/kubelet
+
+# pluck out env vars from kubeadm drop-in and put them into a user-editable location
+
+RUN cat /etc/systemd/system/kubelet.service.d/kubeadm.conf | grep Environment | sed 's/Environment="//g' | sed 's/\=/\=\"/' > /exports/hostfs/etc/kubernetes/kubeadm-env
+
+ENTRYPOINT ["/usr/bin/launch.sh"]

--- a/kubeadm/config.json.template
+++ b/kubeadm/config.json.template
@@ -1,0 +1,401 @@
+{
+    "ociVersion": "1.0.0",
+    "platform": {
+        "os": "linux",
+        "arch": "amd64"
+    },
+    "process": {
+        "terminal": false,
+        "user": {},
+        "args": [
+            "/usr/bin/launch.sh"
+        ],
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "TERM=xterm"
+        ],
+        "noNewPrivileges": false,
+        "cwd": "/",
+        "capabilities": {
+            "bounding": [
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_MAC_OVERRIDE",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND"
+            ],
+            "permitted": [
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_MAC_OVERRIDE",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND"
+            ],
+            "inheritable": [
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_MAC_OVERRIDE",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND"
+            ],
+            "effective": [
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_MAC_OVERRIDE",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND"
+            ],
+            "ambient": [
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_FSETID",
+                "CAP_KILL",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETPCAP",
+                "CAP_LINUX_IMMUTABLE",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_BROADCAST",
+                "CAP_NET_ADMIN",
+                "CAP_NET_RAW",
+                "CAP_IPC_LOCK",
+                "CAP_IPC_OWNER",
+                "CAP_SYS_MODULE",
+                "CAP_SYS_RAWIO",
+                "CAP_SYS_CHROOT",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_PACCT",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_BOOT",
+                "CAP_SYS_NICE",
+                "CAP_SYS_RESOURCE",
+                "CAP_SYS_TIME",
+                "CAP_SYS_TTY_CONFIG",
+                "CAP_MKNOD",
+                "CAP_LEASE",
+                "CAP_AUDIT_WRITE",
+                "CAP_AUDIT_CONTROL",
+                "CAP_SETFCAP",
+                "CAP_MAC_OVERRIDE",
+                "CAP_MAC_ADMIN",
+                "CAP_SYSLOG",
+                "CAP_WAKE_ALARM",
+                "CAP_BLOCK_SUSPEND"
+            ]
+        },
+        "rlimits": [
+            {
+                "type": "RLIMIT_NOFILE",
+                "hard": 1024,
+                "soft": 1024
+            }
+        ]
+    },
+    "root": {
+        "path": "rootfs",
+        "readonly": true
+    },
+    "mounts": [
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc"
+        },
+        {
+            "destination": "/dev",
+            "type": "bind",
+            "source": "/dev",
+            "options": [
+                "rbind",
+                "rslave"
+            ]
+        },
+        {
+            "destination": "/dev/pts",
+            "type": "devpts",
+            "source": "devpts",
+            "options": [
+                "nosuid",
+                "noexec",
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620",
+                "gid=5"
+            ]
+        },
+        {
+            "destination": "/dev/shm",
+            "type": "tmpfs",
+            "source": "shm",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "mode=1777",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/sys",
+            "type": "sysfs",
+            "source": "sysfs",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys/fs/cgroup",
+            "type": "cgroup",
+            "source": "cgroup",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "relatime",
+                "ro"
+            ]
+        },
+        {
+            "type": "bind",
+            "source": "/etc/kubernetes",
+            "destination": "/etc/kubernetes",
+            "options": [
+                "rbind",
+                "ro",
+                "rprivate"
+            ]
+         },
+         {
+            "destination": "/etc/resolv.conf",
+            "type": "bind",
+            "source": "/etc/resolv.conf",
+            "options": [
+                "ro",
+                "rbind",
+                "rprivate"
+             ]
+          },
+          {
+            "type": "bind",
+            "source": "/",
+            "destination": "/rootfs",
+            "options": [
+                "rbind",
+                "rslave",
+                "ro"
+             ]
+          },
+          {
+            "type": "bind",
+            "source": "/var/run/",
+            "destination": "/var/run/",
+            "options": [
+                "rbind",
+                "rw",
+                "mode=755"
+             ]
+          },
+          {
+            "type": "bind",
+            "source": "/run",
+            "destination": "/run",
+            "options": [
+                "rbind",
+                "rw",
+                "mode=755"
+             ]
+          },
+          {
+            "type": "bind",
+            "source": "/var/lib",
+            "destination": "/var/lib",
+            "options": [
+                "bind",
+                "rw",
+                "mode=755"
+             ]
+          },
+          {
+            "type": "bind",
+            "source": "/var/lib/kubelet",
+            "destination": "/var/lib/kubelet",
+            "options": [
+                "rbind",
+                "rslave",
+                "rw",
+                "mode=755"
+             ]
+          },
+          {
+            "type": "bind",
+            "source": "/var/log",
+            "destination": "/var/log",
+            "options": [
+                "bind",
+                "rw",
+                "mode=755"
+             ]
+          },
+          {
+            "type": "bind",
+            "source": "/etc/cni",
+            "destination": "/etc/cni",
+            "options": [
+                "rbind",
+                "ro",
+                "rprivate"
+             ]
+          }
+    ],
+    "linux": {
+        "rootfsPropagation": "rslave",
+        "resources": {
+            "devices": [
+                {
+                    "allow": true,
+                    "access": "rwm"
+                }
+            ]
+        },
+        "namespaces": [
+            {
+                "type": "mount"
+            }
+        ],
+        "devices": null,
+        "apparmorProfile": "",
+        "selinuxProcessLabel": ""
+    }
+}

--- a/kubeadm/config.json.template
+++ b/kubeadm/config.json.template
@@ -395,7 +395,6 @@
             }
         ],
         "devices": null,
-        "apparmorProfile": "",
-        "selinuxProcessLabel": ""
+        "apparmorProfile": ""
     }
 }

--- a/kubeadm/launch.sh
+++ b/kubeadm/launch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+[ -f /etc/kubernetes/kubeadm-env ] && source /etc/kubernetes/kubeadm-env
+[ -f /etc/kubernetes/crio-env ] && source /etc/kubernetes/crio-env
+
+TEMP_KUBELET_ARGS='--cgroups-per-qos=false --enforce-node-allocatable='
+
+exec /usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_CADVISOR_ARGS $KUBELET_CGROUP_ARGS $KUBELET_CERTIFICATE_ARGS $KUBELET_EXTRA_ARGS $TEMP_KUBELET_ARGS --containerized

--- a/kubeadm/service.template
+++ b/kubeadm/service.template
@@ -1,0 +1,16 @@
+[Unit]
+Description=kubernetes-kubelet
+After=docker.service
+
+[Service]
+ExecStart=$EXEC_START
+ExecStop=$EXEC_STOP
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+WorkingDirectory=$DESTDIR
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
A system container for kubeadm, as blogged about at http://www.projectatomic.io/blog/2017/05/testing-system-containerized-kubeadm/, but with fedora containers.

```
atomic install --system --system-package=no --name kubelet docker.io/jasonbrooks/kubeadm
systemctl start kubelet
kubeadm init 
```