### PR TITLE
Docker/CRI-O: ensure /usr/share/rhel exists

### DIFF
--- a/cri-o-centos/tmpfiles.template
+++ b/cri-o-centos/tmpfiles.template
@@ -1,3 +1,4 @@
 d    ${RUN_DIRECTORY}/${NAME}               -        -           -       - -
 d    /etc/crio - - - - -
 Z    /etc/crio - - - - -
+d    /usr/share/rhel - - - - -

--- a/cri-o-fedora/tmpfiles.template
+++ b/cri-o-fedora/tmpfiles.template
@@ -1,3 +1,4 @@
 d    ${RUN_DIRECTORY}/${NAME}               -        -           -       - -
 d    /etc/crio - - - - -
 Z    /etc/crio - - - - -
+d    /usr/share/rhel - - - - -

--- a/docker-centos/tmpfiles.template
+++ b/docker-centos/tmpfiles.template
@@ -1,1 +1,2 @@
 d    /var/lib/docker - - - - -
+d    /usr/share/rhel - - - - -

--- a/docker-fedora/tmpfiles.template
+++ b/docker-fedora/tmpfiles.template
@@ -1,3 +1,4 @@
 d   /var/lib/docker  - - - - -
 d   /var/run/docker  - - - - -
 d   /var/run/containerd  - - - - -
+d    /usr/share/rhel - - - - -


### PR DESCRIPTION
If docker is not installed on the host the `/usr/share/rhel` directory might not be present and runC fails to bind it.  Ensure it exists before the container starts.