### PR TITLE
docker-fedora: change rootfsPropagation to rslave

### DIFF
--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -381,7 +381,7 @@
     ],
     "hooks": {},
     "linux": {
-	"rootfsPropagation": "private",
+	"rootfsPropagation": "rslave",
 	"resources": {
 	    "devices": [
 		{


### PR DESCRIPTION
We probably never tried docker-fedora with Origin before but
docker-centos is already using rootfsPropagation and same for CRI-O, so
sync this container with all the other images.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>