### PR TITLE
CRI-O: set rootfsPropagation to rslave

### DIFF
--- a/cri-o-centos/Dockerfile
+++ b/cri-o-centos/Dockerfile
@@ -11,8 +11,6 @@ LABEL com.redhat.component="cri-o" \
       maintainer="Yu Qi Zhang <jzehrarnyg@gmail.com>" \
       atomic.type="system"
 
-COPY tmpfiles.template config.json.template service.template /exports/
-
 RUN yum-config-manager --nogpgcheck --add-repo https://cbs.centos.org/repos/virt7-docker-common-candidate/x86_64/os/ && \
     yum install --nogpgcheck --setopt=tsflags=nodocs -y iptables cri-o iproute && \
     rpm -V iptables cri-o iproute && \
@@ -20,6 +18,8 @@ RUN yum-config-manager --nogpgcheck --add-repo https://cbs.centos.org/repos/virt
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ && \
     cp /etc/crio/* /exports/hostfs/etc/crio && \
     if test -e /opt/cni/bin; then cp -Lr /opt/cni/bin/* /exports/hostfs/opt/cni/bin/; fi
+
+COPY tmpfiles.template config.json.template service.template /exports/
 
 COPY set_mounts.sh /
 COPY run.sh /usr/bin/

--- a/cri-o-centos/Dockerfile
+++ b/cri-o-centos/Dockerfile
@@ -14,8 +14,8 @@ LABEL com.redhat.component="cri-o" \
 COPY tmpfiles.template config.json.template service.template /exports/
 
 RUN yum-config-manager --nogpgcheck --add-repo https://cbs.centos.org/repos/virt7-docker-common-candidate/x86_64/os/ && \
-    yum install --nogpgcheck --setopt=tsflags=nodocs -y iptables cri-o && \
-    rpm -V iptables cri-o && \
+    yum install --nogpgcheck --setopt=tsflags=nodocs -y iptables cri-o iproute && \
+    rpm -V iptables cri-o iproute && \
     yum clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ && \
     cp /etc/crio/* /exports/hostfs/etc/crio && \

--- a/cri-o-centos/config.json.template
+++ b/cri-o-centos/config.json.template
@@ -237,7 +237,7 @@
                 }
             ]
         },
-        "rootfsPropagation": "private",
+        "rootfsPropagation": "shared",
         "selinuxProcessLabel": "system_u:system_r:container_runtime_t:s0"
     },
     "mounts": [

--- a/cri-o-centos/config.json.template
+++ b/cri-o-centos/config.json.template
@@ -396,7 +396,9 @@
         {
             "destination": "/proc",
             "options": [
-                "private"
+                "rbind",
+                "rw",
+                "mode=755"
             ],
             "source": "/proc",
             "type": "proc"

--- a/cri-o-centos/config.json.template
+++ b/cri-o-centos/config.json.template
@@ -361,6 +361,16 @@
             "type": "bind"
         },
         {
+            "destination": "/var/lib/origin",
+            "options": [
+                "rshared",
+                "rbind",
+                "rw"
+            ],
+            "source": "${STATE_DIRECTORY}/origin",
+            "type": "bind"
+        },
+        {
             "destination": "/opt/cni",
             "options": [
                 "rbind",

--- a/cri-o-centos/set_mounts.sh
+++ b/cri-o-centos/set_mounts.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
+findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
 mount --make-shared /run
-findmnt /var/lib > /dev/null || mount --bind --make-rslave /var/lib /var/lib
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd

--- a/cri-o-centos/set_mounts.sh
+++ b/cri-o-centos/set_mounts.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
+findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd

--- a/cri-o-centos/tmpfiles.template
+++ b/cri-o-centos/tmpfiles.template
@@ -2,3 +2,4 @@ d    ${RUN_DIRECTORY}/${NAME}               -        -           -       - -
 d    /etc/crio - - - - -
 Z    /etc/crio - - - - -
 d    /usr/share/rhel - - - - -
+d    ${STATE_DIRECTORY}/origin               -        -           -       - -

--- a/cri-o-fedora/Dockerfile
+++ b/cri-o-fedora/Dockerfile
@@ -13,8 +13,8 @@ LABEL com.redhat.component="cri-o" \
 
 COPY tmpfiles.template config.json.template service.template /exports/
 
-RUN dnf install --setopt=tsflags=nodocs -y iptables cri-o cri-o-cni && \
-    rpm -V iptables cri-o cri-o-cni && \
+RUN dnf install --setopt=tsflags=nodocs -y iptables cri-o cri-o-cni iproute && \
+    rpm -V iptables cri-o cri-o-cni iproute && \
     dnf clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ && \
     cp /etc/crio/* /exports/hostfs/etc/crio && \

--- a/cri-o-fedora/Dockerfile
+++ b/cri-o-fedora/Dockerfile
@@ -11,14 +11,14 @@ LABEL com.redhat.component="cri-o" \
       maintainer="Yu Qi Zhang <jzehrarnyg@gmail.com>" \
       atomic.type="system"
 
-COPY tmpfiles.template config.json.template service.template /exports/
-
 RUN dnf install --setopt=tsflags=nodocs -y iptables cri-o cri-o-cni iproute && \
     rpm -V iptables cri-o cri-o-cni iproute && \
     dnf clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ && \
     cp /etc/crio/* /exports/hostfs/etc/crio && \
     if test -e /opt/cni/bin; then cp -Lr /opt/cni/bin/* /exports/hostfs/opt/cni/bin/; fi
+
+COPY tmpfiles.template config.json.template service.template /exports/
 
 COPY set_mounts.sh /
 COPY run.sh /usr/bin/

--- a/cri-o-fedora/config.json.template
+++ b/cri-o-fedora/config.json.template
@@ -242,7 +242,7 @@
                 }
             ]
         },
-        "rootfsPropagation": "private",
+        "rootfsPropagation": "shared",
         "selinuxProcessLabel": "system_u:system_r:container_runtime_t:s0"
     },
     "mounts": [

--- a/cri-o-fedora/config.json.template
+++ b/cri-o-fedora/config.json.template
@@ -401,7 +401,9 @@
         {
             "destination": "/proc",
             "options": [
-                "private"
+                "rbind",
+                "rw",
+                "mode=755"
             ],
             "source": "/proc",
             "type": "proc"

--- a/cri-o-fedora/config.json.template
+++ b/cri-o-fedora/config.json.template
@@ -366,6 +366,16 @@
             "type": "bind"
         },
         {
+            "destination": "/var/lib/origin",
+            "options": [
+                "rshared",
+                "rbind",
+                "rw"
+            ],
+            "source": "${STATE_DIRECTORY}/origin",
+            "type": "bind"
+        },
+        {
             "destination": "/opt/cni",
             "options": [
                 "rbind",

--- a/cri-o-fedora/set_mounts.sh
+++ b/cri-o-fedora/set_mounts.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
+findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
 mount --make-shared /run
-findmnt /var/lib > /dev/null || mount --bind --make-rslave /var/lib /var/lib
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd

--- a/cri-o-fedora/set_mounts.sh
+++ b/cri-o-fedora/set_mounts.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
+findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd

--- a/cri-o-fedora/tmpfiles.template
+++ b/cri-o-fedora/tmpfiles.template
@@ -2,3 +2,4 @@ d    ${RUN_DIRECTORY}/${NAME}               -        -           -       - -
 d    /etc/crio - - - - -
 Z    /etc/crio - - - - -
 d    /usr/share/rhel - - - - -
+d    ${STATE_DIRECTORY}/origin               -        -           -       - -


### PR DESCRIPTION
so that the CRI-O container can see the mount points from node when it is running on the host.

It addresses this issue: https://github.com/openshift/openshift-ansible/pull/4898#issuecomment-319462397

@ashcrow I've already built the CentOS based image on Docker hub on top of this PR.

the router is deployed correctly but I am seeing that the registry gets stuck, I am still investigating if it depends from the system container