### PR TITLE
Drop /usr/share/rhel bind mount

### DIFF
--- a/cri-o-centos/config.json.template
+++ b/cri-o-centos/config.json.template
@@ -309,17 +309,6 @@
         },
 	{
 	    "type": "bind",
-	    "source": "/usr/share/rhel",
-	    "destination": "/usr/share/rhel",
-	    "options": [
-		"rprivate",
-		"rbind",
-		"ro",
-		"mode=755"
-	    ]
-	},
-	{
-	    "type": "bind",
 	    "source": "${RUN_DIRECTORY}",
 	    "destination": "/run",
 	    "options": [

--- a/cri-o-centos/tmpfiles.template
+++ b/cri-o-centos/tmpfiles.template
@@ -1,5 +1,4 @@
 d    ${RUN_DIRECTORY}/${NAME}               -        -           -       - -
 d    /etc/crio - - - - -
 Z    /etc/crio - - - - -
-d    /usr/share/rhel - - - - -
 d    ${STATE_DIRECTORY}/origin               -        -           -       - -

--- a/cri-o-fedora/config.json.template
+++ b/cri-o-fedora/config.json.template
@@ -314,17 +314,6 @@
         },
 	{
 	    "type": "bind",
-	    "source": "/usr/share/rhel",
-	    "destination": "/usr/share/rhel",
-	    "options": [
-		"rprivate",
-		"rbind",
-		"ro",
-		"mode=755"
-	    ]
-	},
-	{
-	    "type": "bind",
 	    "source": "${RUN_DIRECTORY}",
 	    "destination": "/run",
 	    "options": [

--- a/cri-o-fedora/tmpfiles.template
+++ b/cri-o-fedora/tmpfiles.template
@@ -1,5 +1,4 @@
 d    ${RUN_DIRECTORY}/${NAME}               -        -           -       - -
 d    /etc/crio - - - - -
 Z    /etc/crio - - - - -
-d    /usr/share/rhel - - - - -
 d    ${STATE_DIRECTORY}/origin               -        -           -       - -

--- a/docker-centos/config.json.template
+++ b/docker-centos/config.json.template
@@ -292,17 +292,6 @@
 	},
 	{
 	    "type": "bind",
-	    "source": "/usr/share/rhel",
-	    "destination": "/usr/share/rhel",
-	    "options": [
-		"rprivate",
-		"rbind",
-		"ro",
-		"mode=755"
-	    ]
-	},
-	{
-	    "type": "bind",
 	    "source": "${RUN_DIRECTORY}",
 	    "destination": "/run",
 	    "options": [

--- a/docker-centos/tmpfiles.template
+++ b/docker-centos/tmpfiles.template
@@ -1,2 +1,1 @@
 d    /var/lib/docker - - - - -
-d    /usr/share/rhel - - - - -

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -297,17 +297,6 @@
 	},
 	{
 	    "type": "bind",
-	    "source": "/usr/share/rhel",
-	    "destination": "/usr/share/rhel",
-	    "options": [
-		"rprivate",
-		"rbind",
-		"ro",
-		"mode=755"
-	    ]
-	},
-	{
-	    "type": "bind",
 	    "source": "${RUN_DIRECTORY}",
 	    "destination": "/run",
 	    "options": [

--- a/docker-fedora/tmpfiles.template
+++ b/docker-fedora/tmpfiles.template
@@ -1,4 +1,3 @@
 d   /var/lib/docker  - - - - -
 d   /var/run/docker  - - - - -
 d   /var/run/containerd  - - - - -
-d    /usr/share/rhel - - - - -


### PR DESCRIPTION
The changes introduced with https://github.com/projectatomic/atomic-system-containers/pull/97 bring some more issues on Atomic Host where `/usr` is immutable.  To avoid any similar issue, drop completely the mount point and expect `/usr/share/rhel` to be present in the container (if needed)