### PR TITLE
Fix SELinux label for system containers

### DIFF
--- a/cri-o-centos/config.json.template
+++ b/cri-o-centos/config.json.template
@@ -205,6 +205,7 @@
                 "CAP_BLOCK_SUSPEND"
             ]
         },
+        "selinuxLabel": "system_u:system_r:container_runtime_t:s0",
         "cwd": "/",
         "env": [
             "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/root/go/bin",
@@ -237,8 +238,7 @@
                 }
             ]
         },
-        "rootfsPropagation": "shared",
-        "selinuxProcessLabel": "system_u:system_r:container_runtime_t:s0"
+        "rootfsPropagation": "shared"
     },
     "mounts": [
         {

--- a/cri-o-fedora/config.json.template
+++ b/cri-o-fedora/config.json.template
@@ -8,6 +8,7 @@
         "args": [
             "/usr/bin/run.sh"
         ],
+        "selinuxLabel": "system_u:system_r:container_runtime_t:s0",
         "capabilities": {
             "ambient": [
                 "CAP_CHOWN",
@@ -242,8 +243,7 @@
                 }
             ]
         },
-        "rootfsPropagation": "shared",
-        "selinuxProcessLabel": "system_u:system_r:container_runtime_t:s0"
+        "rootfsPropagation": "shared"
     },
     "mounts": [
         {

--- a/etcd/config.json.template
+++ b/etcd/config.json.template
@@ -239,7 +239,6 @@
 			}
 		],
 		"devices": null,
-		"apparmorProfile": "",
-		"selinuxProcessLabel": ""
+		"apparmorProfile": ""
 	}
 }

--- a/kubernetes-apiserver/config.json.template
+++ b/kubernetes-apiserver/config.json.template
@@ -178,7 +178,6 @@
             }
         ],
         "devices": null,
-        "apparmorProfile": "",
-        "selinuxProcessLabel": ""
+        "apparmorProfile": ""
     }
 }

--- a/kubernetes-controller-manager/config.json.template
+++ b/kubernetes-controller-manager/config.json.template
@@ -178,7 +178,6 @@
             }
         ],
         "devices": null,
-        "apparmorProfile": "",
-        "selinuxProcessLabel": ""
+        "apparmorProfile": ""
     }
 }

--- a/kubernetes-kubelet/config.json.template
+++ b/kubernetes-kubelet/config.json.template
@@ -385,7 +385,6 @@
             }
         ],
         "devices": null,
-        "apparmorProfile": "",
-        "selinuxProcessLabel": ""
+        "apparmorProfile": ""
     }
 }

--- a/kubernetes-proxy/config.json.template
+++ b/kubernetes-proxy/config.json.template
@@ -353,7 +353,6 @@
             }
         ],
         "devices": null,
-        "apparmorProfile": "",
-        "selinuxProcessLabel": ""
+        "apparmorProfile": ""
     }
 }

--- a/kubernetes-scheduler/config.json.template
+++ b/kubernetes-scheduler/config.json.template
@@ -178,7 +178,6 @@
             }
         ],
         "devices": null,
-        "apparmorProfile": "",
-        "selinuxProcessLabel": ""
+        "apparmorProfile": ""
     }
 }

--- a/lint/syscontainers-lint
+++ b/lint/syscontainers-lint
@@ -154,6 +154,8 @@ def check_config_json(path):
             log(basename, "Readonly must be true", is_error=True)
     if config['process']['terminal']:
             log(basename, "process/terminal must be false", is_error=True)
+    if 'selinuxProcessLabel' in config['linux']:
+            log(basename, "linux/selinuxProcessLabel not valid.  Use process/selinuxLabel", is_error=True)
 
 
 def check_systemd_unit(path):


### PR DESCRIPTION
the SELinux runtime label was moved to `process/selinuxLabel`.

Drop it from system containers that are not using it.

Update the CRI-O system container to correctly use the new label.