### PR TITLE
CRI-O: use system runc

### DIFF
--- a/cri-o-centos/Dockerfile
+++ b/cri-o-centos/Dockerfile
@@ -12,8 +12,8 @@ LABEL com.redhat.component="cri-o" \
       atomic.type="system"
 
 RUN yum-config-manager --nogpgcheck --add-repo https://cbs.centos.org/repos/virt7-docker-common-candidate/x86_64/os/ && \
-    yum install --nogpgcheck --setopt=tsflags=nodocs -y iptables cri-o iproute && \
-    rpm -V iptables cri-o iproute && \
+    yum install --nogpgcheck --setopt=tsflags=nodocs -y iptables cri-o iproute runc && \
+    rpm -V iptables cri-o iproute runc && \
     yum clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ && \
     cp /etc/crio/* /exports/hostfs/etc/crio && \

--- a/cri-o-fedora/Dockerfile
+++ b/cri-o-fedora/Dockerfile
@@ -11,8 +11,8 @@ LABEL com.redhat.component="cri-o" \
       maintainer="Yu Qi Zhang <jzehrarnyg@gmail.com>" \
       atomic.type="system"
 
-RUN dnf install --setopt=tsflags=nodocs -y iptables cri-o iproute && \
-    rpm -V iptables cri-o iproute && \
+RUN dnf install --setopt=tsflags=nodocs -y iptables cri-o iproute runc && \
+    rpm -V iptables cri-o iproute runc && \
     dnf clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ && \
     cp /etc/crio/* /exports/hostfs/etc/crio && \


### PR DESCRIPTION
last versions of CRI-O use runc from the host.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1489358