### PR TITLE
CRI-O: prevent a bind mounts bomb

### DIFF
--- a/cri-o-centos/config.json.template
+++ b/cri-o-centos/config.json.template
@@ -238,7 +238,7 @@
                 }
             ]
         },
-        "rootfsPropagation": "shared"
+        "rootfsPropagation": "private"
     },
     "mounts": [
         {
@@ -343,17 +343,27 @@
             "destination": "/var/lib",
             "options": [
                 "rbind",
-                "rshared",
+                "rprivate",
                 "rw"
             ],
             "source": "${STATE_DIRECTORY}",
             "type": "bind"
         },
         {
+            "destination": "/var/lib/containers",
+            "options": [
+                "rbind",
+                "rshared",
+                "rw"
+            ],
+            "source": "${STATE_DIRECTORY}/containers",
+            "type": "bind"
+        },
+        {
             "destination": "/var/lib/origin",
             "options": [
                 "rshared",
-                "rbind",
+                "bind",
                 "rw"
             ],
             "source": "${STATE_DIRECTORY}/origin",

--- a/cri-o-centos/set_mounts.sh
+++ b/cri-o-centos/set_mounts.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
+findmnt /var/lib/containers > /dev/null || mount --bind --make-shared /var/lib/containers /var/lib/containers
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd

--- a/cri-o-fedora/config.json.template
+++ b/cri-o-fedora/config.json.template
@@ -348,17 +348,27 @@
             "destination": "/var/lib",
             "options": [
                 "rbind",
-                "rshared",
+                "rprivate",
                 "rw"
             ],
             "source": "${STATE_DIRECTORY}",
             "type": "bind"
         },
         {
+            "destination": "/var/lib/containers",
+            "options": [
+                "rbind",
+                "rshared",
+                "rw"
+            ],
+            "source": "${STATE_DIRECTORY}/containers",
+            "type": "bind"
+        },
+        {
             "destination": "/var/lib/origin",
             "options": [
                 "rshared",
-                "rbind",
+                "bind",
                 "rw"
             ],
             "source": "${STATE_DIRECTORY}/origin",

--- a/cri-o-fedora/set_mounts.sh
+++ b/cri-o-fedora/set_mounts.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
+findmnt /var/lib/containers > /dev/null || mount --bind --make-shared /var/lib/containers /var/lib/containers
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd


### PR DESCRIPTION
Under RHELAH I've seen that when cri-o is restarted a few times, we create a lot of mount points.  That is because we are bind mounting as rshared both /var/lib and /var/lib/origin.  We needed /var/lib because     we want to share bind mounts from /var/lib/containers.  Solve it by creating a new bind mount and make /var/lib private.

Marked as WIP as I am still testing it