### PR TITLE
CRI-O: make state directories and /opt/cni configurable

### DIFF
--- a/cri-o-centos/config.json.template
+++ b/cri-o-centos/config.json.template
@@ -356,7 +356,7 @@
                 "rshared",
                 "rw"
             ],
-            "source": "${STATE_DIRECTORY}/containers",
+            "source": "${VAR_LIB_CONTAINERS}",
             "type": "bind"
         },
         {
@@ -366,7 +366,7 @@
                 "bind",
                 "rw"
             ],
-            "source": "${STATE_DIRECTORY}/origin",
+            "source": "${VAR_LIB_ORIGIN}",
             "type": "bind"
         },
         {
@@ -377,7 +377,7 @@
                 "ro",
                 "mode=755"
             ],
-            "source": "/opt/cni",
+            "source": "${OPT_CNI}",
             "type": "bind"
         },
         {

--- a/cri-o-centos/manifest.json
+++ b/cri-o-centos/manifest.json
@@ -1,0 +1,8 @@
+{
+    "version": "1.0",
+    "defaultValues": {
+        "OPT_CNI" : "/opt/cni",
+        "VAR_LIB_CONTAINERS" : "/var/lib/containers",
+        "VAR_LIB_ORIGIN" : "/var/lib/origin"
+    }
+}

--- a/cri-o-fedora/config.json.template
+++ b/cri-o-fedora/config.json.template
@@ -243,7 +243,7 @@
                 }
             ]
         },
-        "rootfsPropagation": "shared"
+        "rootfsPropagation": "private"
     },
     "mounts": [
         {

--- a/cri-o-fedora/config.json.template
+++ b/cri-o-fedora/config.json.template
@@ -361,7 +361,7 @@
                 "rshared",
                 "rw"
             ],
-            "source": "${STATE_DIRECTORY}/containers",
+            "source": "${VAR_LIB_CONTAINERS}",
             "type": "bind"
         },
         {
@@ -371,7 +371,7 @@
                 "bind",
                 "rw"
             ],
-            "source": "${STATE_DIRECTORY}/origin",
+            "source": "${VAR_LIB_ORIGIN}",
             "type": "bind"
         },
         {
@@ -382,7 +382,7 @@
                 "ro",
                 "mode=755"
             ],
-            "source": "/opt/cni",
+            "source": "${OPT_CNI}",
             "type": "bind"
         },
         {

--- a/cri-o-fedora/manifest.json
+++ b/cri-o-fedora/manifest.json
@@ -1,0 +1,8 @@
+{
+    "version": "1.0",
+    "defaultValues": {
+        "OPT_CNI" : "/opt/cni",
+        "VAR_LIB_CONTAINERS" : "/var/lib/containers",
+        "VAR_LIB_ORIGIN" : "/var/lib/origin"
+    }
+}


### PR DESCRIPTION
In case the directories on the host are in different places, allow a quick way to configure them.