### PR TITLE
flannel: allow devices

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -11,8 +11,8 @@ container:
 
 tests:
     # temp workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1483553
-    - if (dnf upgrade -y || :) |& grep -q -e BDB1539; then
-      rpm --rebuilddb; dnf upgrade -y;
+    - if (dnf distro-sync -y || :) |& grep -q -e BDB1539; then
+      rpm --rebuilddb; dnf distro-sync;
       fi; dnf install -y python findutils git golang-bin yajl
     - ./test.sh
 

--- a/flannel/config.json.template
+++ b/flannel/config.json.template
@@ -202,7 +202,7 @@
 		"resources": {
 			"devices": [
 				{
-					"allow": false,
+					"allow": true,
 					"access": "rwm"
 				}
 			]


### PR DESCRIPTION
we are already bind mounting /dev, so allow devices to be used inside
the container.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>