### PR TITLE
cri-o, docker: rbind /var/lib

### DIFF
--- a/cri-o-centos/set_mounts.sh
+++ b/cri-o-centos/set_mounts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
+findmnt /var/lib > /dev/null || mount --rbind --make-shared /var/lib /var/lib
 findmnt /var/lib/containers > /dev/null || mount --bind --make-shared /var/lib/containers /var/lib/containers
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run

--- a/cri-o-fedora/set_mounts.sh
+++ b/cri-o-fedora/set_mounts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
+findmnt /var/lib > /dev/null || mount --rbind --make-shared /var/lib /var/lib
 findmnt /var/lib/containers > /dev/null || mount --bind --make-shared /var/lib/containers /var/lib/containers
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run

--- a/docker-fedora/set_mounts.sh
+++ b/docker-fedora/set_mounts.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-findmnt /var/lib > /dev/null || mount --bind --make-shared /var/lib /var/lib
+findmnt /var/lib > /dev/null || mount --rbind --make-shared /var/lib /var/lib
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd


### PR DESCRIPTION
so we don't shadow /var/lib/docker when it is already mounted.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1493714