### PR TITLE
unset KUBELET_API_SERVER

### DIFF
--- a/kubernetes-kubelet/launch.sh
+++ b/kubernetes-kubelet/launch.sh
@@ -2,6 +2,7 @@
 
 source /etc/kubernetes/kubelet
 source /etc/kubernetes/config
+unset KUBELET_API_SERVER
 
 TEMP_KUBELET_ARGS='--cgroup-driver=systemd --cgroups-per-qos=false --enforce-node-allocatable='
 


### PR DESCRIPTION
Until the PR [1] below is merged and new packages are built,
we need to unset the env variable KUBELET_API_SERVER
because "--api-servers" has been removed from kubelet in
kubernetes 1.8.x.

[1] https://github.com/kubernetes/contrib/pull/2766

The api-server is recommended to be passed to kubelet with kubeconfig since 1.6.x.