### PR TITLE
cri-o-centos: use runc from cbs.centos.org

### DIFF
--- a/cri-o-centos/Dockerfile
+++ b/cri-o-centos/Dockerfile
@@ -12,7 +12,7 @@ LABEL com.redhat.component="cri-o" \
       atomic.type="system"
 
 RUN yum-config-manager --nogpgcheck --add-repo https://cbs.centos.org/repos/virt7-container-common-candidate/x86_64/os/ && \
-    yum install --nogpgcheck --setopt=tsflags=nodocs -y iptables cri-o iproute runc && \
+    yum install --disablerepo=extras --nogpgcheck --setopt=tsflags=nodocs -y iptables cri-o iproute runc && \
     rpm -V iptables cri-o iproute runc && \
     yum clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ && \


### PR DESCRIPTION
Disable extras so that runc is installed from the same repository as
CRI-O.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>