### PR TITLE
drop /var/lib bind mount completely in the host

### DIFF
--- a/cri-o-centos/config.json.template
+++ b/cri-o-centos/config.json.template
@@ -350,13 +350,13 @@
             "type": "bind"
         },
         {
-            "destination": "/var/lib/containers",
+            "destination": "/var/lib/containers/storage",
             "options": [
                 "rbind",
                 "rshared",
                 "rw"
             ],
-            "source": "${VAR_LIB_CONTAINERS}",
+            "source": "${VAR_LIB_CONTAINERS_STORAGE}",
             "type": "bind"
         },
         {

--- a/cri-o-centos/manifest.json
+++ b/cri-o-centos/manifest.json
@@ -2,7 +2,7 @@
     "version": "1.0",
     "defaultValues": {
         "OPT_CNI" : "/opt/cni",
-        "VAR_LIB_CONTAINERS" : "/var/lib/containers",
+        "VAR_LIB_CONTAINERS_STORAGE" : "/var/lib/containers/storage",
         "VAR_LIB_ORIGIN" : "/var/lib/origin"
     }
 }

--- a/cri-o-centos/set_mounts.sh
+++ b/cri-o-centos/set_mounts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-findmnt /var/lib/containers > /dev/null || mount --bind --make-shared /var/lib/containers /var/lib/containers
+findmnt /var/lib/containers/storage > /dev/null || mount --bind --make-shared /var/lib/containers/storage /var/lib/containers/storage
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd

--- a/cri-o-centos/set_mounts.sh
+++ b/cri-o-centos/set_mounts.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-findmnt /var/lib > /dev/null || mount --rbind --make-shared /var/lib /var/lib
 findmnt /var/lib/containers > /dev/null || mount --bind --make-shared /var/lib/containers /var/lib/containers
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run

--- a/cri-o-fedora/config.json.template
+++ b/cri-o-fedora/config.json.template
@@ -361,7 +361,7 @@
                 "rshared",
                 "rw"
             ],
-            "source": "${VAR_LIB_CONTAINERS}",
+            "source": "${VAR_LIB_CONTAINERS_STORAGE}",
             "type": "bind"
         },
         {

--- a/cri-o-fedora/manifest.json
+++ b/cri-o-fedora/manifest.json
@@ -2,7 +2,7 @@
     "version": "1.0",
     "defaultValues": {
         "OPT_CNI" : "/opt/cni",
-        "VAR_LIB_CONTAINERS" : "/var/lib/containers",
+        "VAR_LIB_CONTAINERS_STORAGE" : "/var/lib/containers/storage",
         "VAR_LIB_ORIGIN" : "/var/lib/origin"
     }
 }

--- a/cri-o-fedora/set_mounts.sh
+++ b/cri-o-fedora/set_mounts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-findmnt /var/lib/containers > /dev/null || mount --bind --make-shared /var/lib/containers /var/lib/containers
+findmnt /var/lib/containers/storage > /dev/null || mount --bind --make-shared /var/lib/containers/storage /var/lib/containers/storage
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd

--- a/cri-o-fedora/set_mounts.sh
+++ b/cri-o-fedora/set_mounts.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-findmnt /var/lib > /dev/null || mount --rbind --make-shared /var/lib /var/lib
 findmnt /var/lib/containers > /dev/null || mount --bind --make-shared /var/lib/containers /var/lib/containers
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run

--- a/docker-fedora/set_mounts.sh
+++ b/docker-fedora/set_mounts.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-findmnt /var/lib > /dev/null || mount --rbind --make-shared /var/lib /var/lib
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd


### PR DESCRIPTION
Having a rbind bind mount on /var/lib is causing all sort of issues in the host (e.g. ostree storage on two different file systems), so drop it completely and in case we will need to create mounts in the host under /var/lib, we will deal with that more specifically.

Marked as WIP for now, as I am still testing this change
