### PR TITLE
Create cri-o storage directory

### DIFF
--- a/cri-o-centos/Dockerfile
+++ b/cri-o-centos/Dockerfile
@@ -15,7 +15,7 @@ RUN yum-config-manager --nogpgcheck --add-repo https://cbs.centos.org/repos/virt
     yum install --disablerepo=extras --nogpgcheck --setopt=tsflags=nodocs -y iptables cri-o iproute runc && \
     rpm -V iptables cri-o iproute runc && \
     yum clean all && \
-    mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ && \
+    mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ /exports/hostfs/var/lib/containers/storage/ && \
     cp /etc/crio/* /exports/hostfs/etc/crio && \
     if test -e /opt/cni/bin; then cp -Lr /opt/cni/bin/* /exports/hostfs/opt/cni/bin/; fi
 

--- a/cri-o-fedora/Dockerfile
+++ b/cri-o-fedora/Dockerfile
@@ -14,7 +14,7 @@ LABEL com.redhat.component="cri-o" \
 RUN dnf install --setopt=tsflags=nodocs -y iptables cri-o iproute runc && \
     rpm -V iptables cri-o iproute runc && \
     dnf clean all && \
-    mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ && \
+    mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ /exports/hostfs/var/lib/containers/storage/ && \
     cp /etc/crio/* /exports/hostfs/etc/crio && \
     if test -e /opt/cni/bin; then cp -Lr /opt/cni/bin/* /exports/hostfs/opt/cni/bin/; fi
 


### PR DESCRIPTION
When testing I noticed a failure on Fedora 26 as ``/var/lib/containers/storage`` didn't already exist. These commits add ``/var/lib/containers/storage`` to ``/exports/hostfs``.