### PR TITLE
doc: Add USAGE.md and blog links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,7 @@ ostree utility installed.
 
 For more information on system containers see:
 
-http://www.projectatomic.io/blog/2016/09/intro-to-system-containers
+- [Basic usage](USAGE.md)
+- http://www.projectatomic.io/blog/2016/09/intro-to-system-containers
+- http://www.projectatomic.io/blog/2017/06/creating-system-containers/
+- http://www.projectatomic.io/blog/2017/09/running-kubernetes-on-fedora-atomic-26/

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,60 @@
+# Installing System Containers
+
+Installing system containers requires the ``atomic`` command.
+
+## First: Pull the image
+
+Pull from registry into ostree:
+
+```
+# atomic pull --storage ostree $REGISTRY/$IMAGE:$TAG
+```
+
+Or alternatively, pull from local docker:
+
+```
+# atomic pull --storage ostree docker:$IMAGE:$TAG
+```
+
+## Install the container
+
+**Note**: Currently we recommend using --system-package=no to avoid having rpmbuild
+create an rpm file during installation. This flag will tell the atomic CLI to fall
+back to copying files to the host instead.
+
+
+### Install without parameters
+```
+# atomic install --system --system-package=no --name=$NAME_FOR_SYSTEMD $REGISTRY/$IMAGE:$TAG
+```
+
+### Install with parameters
+Some system containers can take in parameters. These parameters should be listed in
+the system containers own README.md file. If for some reason a README.md does not
+exist, one can check the ``defaultValues`` in the ``manifest.json`` file for
+parameters to override.
+
+```
+# atomic install --system --system-package=no --name=$NAME_FOR_SYSTEMD \
+  --set=KEY=VAL --set=FOO=BAR $REGISTRY/$IMAGE:$TAG
+```
+
+## Running System Containers
+
+### Start as a systemd service
+
+```
+# systemctl start $NAME_FOR_SYSTEMD
+```
+
+### Stopping the service
+
+```
+# systemctl stop $NAME_FOR_SYSTEMD
+```
+
+## Uninstalling System Containers
+
+```
+# atomic uninstall $NAME_FOR_SYSTEMD
+```


### PR DESCRIPTION
Came up in IRC that we didn't have a quick doc explaining how to use system containers from a user perspective.

USAGE.md houses basic usage information for using system containers.