### PR TITLE
Enable mount propagation in /var/lib/kubelet

### DIFF
--- a/kubernetes-kubelet/config.json.template
+++ b/kubernetes-kubelet/config.json.template
@@ -353,7 +353,7 @@
             "destination": "/var/lib/kubelet",
             "options": [
                 "rbind",
-                "rslave",
+                "rshared",
                 "rw",
                 "mode=755"
              ]


### PR DESCRIPTION
Cases where an external volume driver manages the bind mounts to be made
available to containers in a different namespace need mount propagation
on /var/lib/kubelet. An example would be a driver relying on FlexVolume
which is doing the pod bind mount to a shared filesystem.