### PR TITLE
Update to current standards

### DIFF
--- a/azure/Dockerfile
+++ b/azure/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:latest
-RUN yum -y install WALinuxAgent && yum -y clean all
+RUN yum -y --setopt=tsflags=nodocs install WALinuxAgent && yum -y clean all
 COPY exports/service.template /exports/
 LABEL Name="azure" \
       Version="0.1" \

--- a/hello-world/Dockerfile
+++ b/hello-world/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora
-RUN dnf install -y nmap-ncat && dnf clean all
+RUN dnf install --setopt=tsflags=nodocs -y nmap-ncat && dnf clean all
 
 COPY run.sh greet.sh /usr/bin/
 COPY manifest.json service.template config.json.template /exports/

--- a/kubernetes-apiserver/Dockerfile
+++ b/kubernetes-apiserver/Dockerfile
@@ -1,5 +1,4 @@
 FROM kubernetes-master:rawhide
-MAINTAINER "Jason Brooks" <jbrooks@redhat.com>
 
 ENV container=docker
 
@@ -9,7 +8,8 @@ LABEL bzcomponent="$NAME" \
         version="$VERSION" \
         release="$RELEASE.$DISTTAG" \
         architecture="$ARCH" \
-        atomic.type='system'
+        atomic.type='system' \
+        maintainer="Jason Brooks <jbrooks@redhat.com>"
 
 COPY launch.sh /usr/bin/kube-apiserver-docker.sh
 

--- a/kubernetes-controller-manager/Dockerfile
+++ b/kubernetes-controller-manager/Dockerfile
@@ -1,5 +1,4 @@
 FROM kubernetes-master:rawhide
-MAINTAINER "Jason Brooks" <jbrooks@redhat.com>
 
 ENV container=docker
 
@@ -9,7 +8,8 @@ LABEL bzcomponent="$NAME" \
         version="$VERSION" \
         release="$RELEASE.$DISTTAG" \
         architecture="$ARCH" \
-        atomic.type='system'
+        atomic.type='system' \
+        maintainer="Jason Brooks <jbrooks@redhat.com>"
 
 COPY launch.sh /usr/bin/kube-controller-manager-docker.sh
 

--- a/kubernetes-kubelet/Dockerfile
+++ b/kubernetes-kubelet/Dockerfile
@@ -1,5 +1,4 @@
 FROM kubernetes-node:rawhide
-MAINTAINER "Jason Brooks" <jbrooks@redhat.com>
 
 ENV container=docker
 
@@ -9,10 +8,11 @@ LABEL bzcomponent="$NAME" \
         version="$VERSION" \
         release="$RELEASE.$DISTTAG" \
         architecture="$ARCH" \
-        atomic.type='system'
+        atomic.type='system' \
+        maintainer="Jason Brooks <jbrooks@redhat.com>"
 
 # Containerized kubelet requires nsenter
-RUN dnf install -y util-linux ethtool systemd-udev e2fsprogs xfsprogs && dnf clean all
+RUN dnf install -y --setopt=tsflags=nodocs util-linux ethtool systemd-udev e2fsprogs xfsprogs && dnf clean all
 
 LABEL RUN /usr/bin/docker run -d --privileged --net=host --pid=host -v /:/rootfs:ro -v /sys:/sys:rw -v /var/run:/var/run:rw -v /run:/run:rw -v /var/lib/docker:/var/lib/docker:rw -v /var/lib/kubelet:/var/lib/kubelet:slave -v /var/log/containers:/var/log/containers:rw
 

--- a/kubernetes-master/Dockerfile
+++ b/kubernetes-master/Dockerfile
@@ -1,13 +1,13 @@
 FROM registry.fedoraproject.org/fedora:rawhide
-MAINTAINER "Jason Brooks" <jbrooks@redhat.com>
 
 ENV NAME=kubernetes-master VERSION=0 RELEASE=0 ARCH=x86_64
 LABEL bzcomponent="$NAME" \
         name="$FGC/$NAME" \
         version="$VERSION" \
         release="$RELEASE.$DISTTAG" \
-        architecture="$ARCH"
+        architecture="$ARCH" \
+        maintainer="Jason Brooks <jbrooks@redhat.com>"
 
-RUN dnf -y update && dnf clean all
+RUN dnf -y --setopt=tsflags=nodocs update && dnf clean all
 RUN groupadd -g 994 kube && useradd -u 996 -g 994 kube
 RUN dnf install -y kubernetes-master findutils && dnf clean all

--- a/kubernetes-node/Dockerfile
+++ b/kubernetes-node/Dockerfile
@@ -1,12 +1,12 @@
 FROM registry.fedoraproject.org/fedora:rawhide
-MAINTAINER "Jason Brooks" <jbrooks@redhat.com>
 
 ENV NAME=kubernetes-node VERSION=0 RELEASE=0 ARCH=x86_64
 LABEL bzcomponent="$NAME" \
         name="$FGC/$NAME" \
         version="$VERSION" \
         release="$RELEASE.$DISTTAG" \
-        architecture="$ARCH"
+        architecture="$ARCH" \
+        maintainer="Jason Brooks <jbrooks@redhat.com>"
 
-RUN dnf -y update && dnf clean all
-RUN dnf install -y kubernetes-node findutils && dnf clean all
+RUN dnf -y --setopt=tsflags=nodocs update && dnf clean all
+RUN dnf install -y --setopt=tsflags=nodocs kubernetes-node findutils && dnf clean all

--- a/kubernetes-proxy/Dockerfile
+++ b/kubernetes-proxy/Dockerfile
@@ -1,6 +1,4 @@
 FROM kubernetes-node:rawhide
-MAINTAINER "Jason Brooks" <jbrooks@redhat.com>
-
 ENV container=docker
 
 ENV NAME=kubernetes-proxy VERSION=0 RELEASE=8 ARCH=x86_64
@@ -9,9 +7,10 @@ LABEL bzcomponent="$NAME" \
         version="$VERSION" \
         release="$RELEASE.$DISTTAG" \
         architecture="$ARCH" \
-        atomic.type='system'
+        atomic.type='system' \
+        maintainer="Jason Brooks <jbrooks@redhat.com>"
 
-RUN dnf install -y iptables conntrack-tools && dnf clean all
+RUN dnf install -y --setopt=tsflags=nodocs iptables conntrack-tools && dnf clean all
 
 LABEL RUN /usr/bin/docker run -d --privileged --net=host 
 

--- a/kubernetes-scheduler/Dockerfile
+++ b/kubernetes-scheduler/Dockerfile
@@ -1,6 +1,4 @@
 FROM kubernetes-master:rawhide
-MAINTAINER "Jason Brooks" <jbrooks@redhat.com>
-
 ENV container=docker
 
 ENV NAME=kubernetes-scheduler VERSION=0.1 RELEASE=8 ARCH=x86_64
@@ -9,7 +7,8 @@ LABEL bzcomponent="$NAME" \
         version="$VERSION" \
         release="$RELEASE.$DISTTAG" \
         architecture="$ARCH" \
-        atomic.type='system'
+        atomic.type='system' \
+        maintainer="Jason Brooks <jbrooks@redhat.com>"
 
 COPY launch.sh /usr/bin/kube-scheduler-docker.sh
 

--- a/lint/syscontainers-lint
+++ b/lint/syscontainers-lint
@@ -106,6 +106,7 @@ def check_git(path):
             if "modified" in subprocess.check_output(["git", "-C", path, "status", i]):
                 log(i, "file has not staged changes")
 
+
 def preprocess_from_manifest(path, content):
     manifest_path = os.path.join(path, 'manifest.json')
     if not os.path.exists(manifest_path):
@@ -117,6 +118,7 @@ def preprocess_from_manifest(path, content):
         values = manifest['defaultValues']
         template = Template(content)
         return template.safe_substitute(values)
+
 
 def check_config_json(path):
     preprocess = False
@@ -241,7 +243,7 @@ if __name__ == '__main__':
         with open(sys.argv[2], 'r') as f:
             content = f.read()
             print(preprocess_from_manifest(sys.argv[1], content))
-            sys.exit(0)
+            raise SystemExit(0)
 
     try:
         check(sys.argv[1])

--- a/ovirt-guest-agent-centos/Dockerfile
+++ b/ovirt-guest-agent-centos/Dockerfile
@@ -9,7 +9,7 @@ LABEL summary="The oVirt Guest Agent" \
 
 ADD logger_conf /root/logger_conf
 
-RUN yum install epel-release -y; yum -y install ovirt-guest-agent-common
+RUN yum install epel-release -y --setopt=tsflags=nodocs; yum -y --setopt=tsflags=nodocs install ovirt-guest-agent-common
 RUN cat /root/logger_conf >> /etc/ovirt-guest-agent.conf && rm /root/logger_conf
 
 COPY ovirt-container-shutdown.sh prep.sh /usr/local/bin/

--- a/ovirt-guest-agent-fedora/Dockerfile
+++ b/ovirt-guest-agent-fedora/Dockerfile
@@ -9,7 +9,7 @@ LABEL summary="The oVirt Guest Agent" \
 
 ADD logger_conf /root/logger_conf
 
-RUN dnf -y install ovirt-guest-agent-common
+RUN dnf -y install --setopt=tsflags=nodocs ovirt-guest-agent-common
 RUN cat /root/logger_conf >> /etc/ovirt-guest-agent.conf && rm /root/logger_conf
 
 COPY ovirt-container-shutdown.sh prep.sh /usr/local/bin/

--- a/qemu-guest-agent/Dockerfile
+++ b/qemu-guest-agent/Dockerfile
@@ -7,7 +7,7 @@ LABEL summary="The QEMU Guest Agent" \
       architecture="x86_64" \
       maintainer="Vinzenz Feenstra <evilissimo@redhat.com>"
 
-RUN yum -y install qemu-guest-agent
+RUN yum -y --setopt=tsflags=nodocs install qemu-guest-agent
 RUN /bin/mkdir -p /etc/qemu
 COPY qemu-ga.conf /etc/qemu/
 COPY service.template tmpfiles.template config.json.template /exports/


### PR DESCRIPTION
- Replaces ``MAINTAINER`` with the ``maintainer`` label.
- ``yum``/``dnf`` now using ``--setopt=tsflags=nodocs``

**Note**: There are some other warnings that still are printed out

- ``found mount point /var/lib.  Use ${STATE_DIRECTORY} instead``
- ``found mount point /run.  Use ${RUN_DIRECTORY} instead``

Should I move these over to use the variables or should we keep with the hard coding?