### PR TITLE
Follow on to lint fixes

### DIFF
--- a/lint/syscontainers-lint
+++ b/lint/syscontainers-lint
@@ -143,7 +143,7 @@ def check_config_json(path):
 
     config = json.loads(content)
 
-    for b in config['mounts']:
+    for b in config.get('mounts', {}):
         if 'source' not in b:
             continue
         if b['type'] == "rbind":
@@ -153,14 +153,14 @@ def check_config_json(path):
         if template and b['source'].startswith("/run"):
             log(basename, "found mount point /run.  Use ${RUN_DIRECTORY} instead")
 
-    if config['root']['path'] != 'rootfs':
-            log(basename, "Path must be 'rootfs'")
-    if not config['root']['readonly']:
-            log(basename, "Readonly must be true", is_error=True)
-    if config['process']['terminal']:
-            log(basename, "process/terminal must be false", is_error=True)
-    if 'selinuxProcessLabel' in config['linux']:
-            log(basename, "linux/selinuxProcessLabel not valid.  Use process/selinuxLabel", is_error=True)
+    if config.get('root', {}).get('path', '') != 'rootfs':
+        log(basename, "root/path must be 'rootfs'")
+    if not config.get('root', {}).get('readonly', False):
+        log(basename, "root/readonly must be true", is_error=True)
+    if config.get('process', {}).get('terminal', True):
+        log(basename, "process/terminal must be false", is_error=True)
+    if 'selinuxProcessLabel' in config.get('linux', {}):
+        log(basename, "linux/selinuxProcessLabel not valid.  Use process/selinuxLabel", is_error=True)
 
 
 def check_systemd_unit(path):

--- a/lint/syscontainers-lint
+++ b/lint/syscontainers-lint
@@ -125,8 +125,11 @@ def check_config_json(path):
     if os.path.exists(os.path.join(path, "config.json")):
         basename = "config.json"
         template = False
-        log("config.json", "file found, it does not support template substitutions.  Use config.json.template instead.")
+        log("config.json", ("file found, it does not support template "
+                            "substitutions. Use config.json.template instead."),
+            True)
     elif not os.path.exists(os.path.join(path, "config.json.template")):
+        log("config.json.template", "Missing config.json.template file. A default will be used.")
         return
     else:
         basename = "config.json.template"

--- a/lint/syscontainers-lint
+++ b/lint/syscontainers-lint
@@ -188,6 +188,7 @@ def check_systemd_unit(path):
 def check_manifest_json(path):
     basename = "manifest.json"
     if not os.path.exists(os.path.join(path, basename)):
+        log(basename, "Missing manifest.json file. A default will be used.")
         return
     with open(os.path.join(path, basename), 'r') as f:
         content = f.read()

--- a/lint/syscontainers-lint
+++ b/lint/syscontainers-lint
@@ -1,4 +1,4 @@
-#!/usr/bin/python -Es
+#!/usr/bin/env python
 # Copyright (C) 2016 Red Hat
 # AUTHOR: Giuseppe Scrivano <gscrivan@redhat.com>
 
@@ -26,11 +26,21 @@ import json
 from string import Template
 
 
-class LintRuntimeError(BaseException):
+class LintRuntimeError(Exception):
+    """
+    Lint specific error which causes the end of lint logic.
+    """
     def __init__(self, error):
+        """
+        Creates a new instance of the LintRuntimeError.
+
+        :param error: Error message
+        :type error: str
+        """
         self.error = error
 
 
+#: All files which will be checked by the linter
 ALL_FILES = [
     "config.json.template",
     "manifest.json",
@@ -39,7 +49,9 @@ ALL_FILES = [
 ]
 
 
+#: If any warning was found during linting
 FOUND_ANY_WARNING = False
+#: If any error was found during linting
 FOUND_ANY_ERROR = False
 
 
@@ -94,7 +106,7 @@ def check_dockerfile(path, dockerfile):
 
 def check_git(path):
     try:
-        subprocess.check_output(["git", "-C", path, "status"])
+        subprocess.check_output(["git", "-C", path, "status"]).decode('utf-8')
     except (OSError, subprocess.CalledProcessError):
         splits = os.path.split(path)
         log(splits[1] or os.path.split(splits[0])[1], "The project is not using git.  Why?")
@@ -103,7 +115,8 @@ def check_git(path):
     for i in ALL_FILES + ["Dockerfile"]:
         filepath = os.path.join(path, i)
         if os.path.exists(filepath):
-            if "modified" in subprocess.check_output(["git", "-C", path, "status", i]):
+            if "modified" in subprocess.check_output([
+                    "git", "-C", path, "status", i]).decode('utf-8'):
                 log(i, "file has not staged changes")
 
 

--- a/lint/syscontainers-lint
+++ b/lint/syscontainers-lint
@@ -163,6 +163,7 @@ def check_config_json(path):
 def check_systemd_unit(path):
     basename = "service.template"
     if not os.path.exists(os.path.join(path, basename)):
+        log(basename, "Missing service.template file. A default will be used.")
         return
     with open(os.path.join(path, basename), 'r') as f:
         content = preprocess_from_manifest(path, f.read())


### PR DESCRIPTION
- Warn on missing files
- Error when ``config.json`` is used
- No longer throw stack trace is ``config.json``/``config.json.template`` is malformed
- Work on Python 2 and 3