### PR TITLE
Fix the example for atomic.run in LABELS.md

### DIFF
--- a/LABELS.md
+++ b/LABELS.md
@@ -26,7 +26,7 @@ and then removed.
 
 ### Example
 ```
-atomic.type="once"
+atomic.run="once"
 ```
 
 


### PR DESCRIPTION
The sample for 'atomic.run' lable has been wrongly typed as
'atomic.type'. Correct the sample to relfect the correct lable
name.