### PR TITLE
cri-o-*: fix debug flag

### DIFF
--- a/cri-o-centos/run.sh
+++ b/cri-o-centos/run.sh
@@ -5,4 +5,4 @@ PID=$$
 LABEL=`tr -d '\000' < /proc/$PID/attr/current`
 printf %s $LABEL > /proc/self/attr/exec
 
-exec /usr/bin/crio --debug
+exec /usr/bin/crio --log-level=debug

--- a/cri-o-fedora/run.sh
+++ b/cri-o-fedora/run.sh
@@ -5,4 +5,4 @@ PID=$$
 LABEL=`tr -d '\000' < /proc/$PID/attr/current`
 printf %s $LABEL > /proc/self/attr/exec
 
-exec /usr/bin/crio --debug
+exec /usr/bin/crio --log-level=debug


### PR DESCRIPTION
Live debugging the machine in https://ci.openshift.redhat.com/jenkins/job/test_branch_origin_extended_conformance_crio/ that were failing over the last month I found that (at least) one of the issue is:
```
Oct 16 09:02:33 ip-172-18-3-142.ec2.internal runc[1318]: time="2017-10-16T09:02:33Z" level=fatal msg="flag provided but not defined: -debug"
```

This PR fixes that and hopefully we won't have any other issue in start the crio service in the CI

@mrunalp @giuseppe @rhatdan  PTAL and merge asap :)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>