### PR TITLE
CRI-O: rbind storage path

### DIFF
--- a/cri-o-centos/set_mounts.sh
+++ b/cri-o-centos/set_mounts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-findmnt /var/lib/containers/storage > /dev/null || mount --bind --make-shared /var/lib/containers/storage /var/lib/containers/storage
+findmnt /var/lib/containers/storage > /dev/null || mount --rbind --make-shared /var/lib/containers/storage /var/lib/containers/storage
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd

--- a/cri-o-fedora/set_mounts.sh
+++ b/cri-o-fedora/set_mounts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-findmnt /var/lib/containers/storage > /dev/null || mount --bind --make-shared /var/lib/containers/storage /var/lib/containers/storage
+findmnt /var/lib/containers/storage > /dev/null || mount --rbind --make-shared /var/lib/containers/storage /var/lib/containers/storage
 findmnt /var/lib/origin > /dev/null || mount --bind --make-shared /var/lib/origin /var/lib/origin
 mount --make-shared /run
 findmnt /run/systemd > /dev/null || mount --bind --make-rslave /run/systemd /run/systemd


### PR DESCRIPTION
Use rbind so we don't cover any existing mount point on /var/lib/containers/storage/overlay.    We  observed this issue when Skopeo was used to copy images to the  overlay storage before CRI-O was running.  Skopeo created a bind mount  on /var/lib/containers/storage/overlay that was not accessible anymore once we covered it with /var/lib/containers/storage.

CRI-O would think /var/lib/containers/storage/overlay by parsing /proc/self/mountinfo would believe the mount point is already there and thus failing to make it PRIVATE.
