### PR TITLE
fix uid/gid, bind mount /var/run/kubernetes in apiserver

### DIFF
--- a/kubernetes-apiserver/config.json.template
+++ b/kubernetes-apiserver/config.json.template
@@ -7,8 +7,8 @@
     "process": {
         "terminal": false,
         "user": {
-            "uid": 994,
-            "gid": 996
+            "uid": 996,
+            "gid": 994
         },
         "args": [
             "/usr/bin/kube-apiserver-docker.sh"
@@ -155,6 +155,15 @@
                 "rbind",
                 "rprivate"
              ]
+          },
+          {
+             "destination": "/var/run/kubernetes",
+             "type": "bind",
+             "source": "/var/run/kubernetes",
+             "options": [
+                 "rw",
+                 "rbind"
+              ]
           }
     ],
     "linux": {

--- a/kubernetes-controller-manager/config.json.template
+++ b/kubernetes-controller-manager/config.json.template
@@ -7,8 +7,8 @@
     "process": {
         "terminal": false,
         "user": {
-            "uid": 994,
-            "gid": 996
+            "uid": 996,
+            "gid": 994
         },
         "args": [
             "/usr/bin/kube-controller-manager-docker.sh"

--- a/kubernetes-scheduler/config.json.template
+++ b/kubernetes-scheduler/config.json.template
@@ -7,8 +7,8 @@
     "process": {
         "terminal": false,
         "user": {
-            "uid": 994,
-            "gid": 996
+            "uid": 996,
+            "gid": 994
         },
         "args": [
             "/usr/bin/kube-scheduler-docker.sh"


### PR DESCRIPTION
kube-apiserver needs to write a cert to /var/run/kubernetes if another cert dir isn't provided. 

atomic hosts come with the kube user set to 996 and group to 994, and I had these reversed

fixes #133 