### PR TITLE
cri-o-*: set systemd limits

### DIFF
--- a/cri-o-centos/service.template
+++ b/cri-o-centos/service.template
@@ -10,6 +10,10 @@ ExecStop=$EXEC_STOP
 Restart=on-failure
 WorkingDirectory=$DESTDIR
 RuntimeDirectory=${NAME}
+TasksMax=infinity
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/cri-o-fedora/service.template
+++ b/cri-o-fedora/service.template
@@ -10,6 +10,10 @@ ExecStop=$EXEC_STOP
 Restart=on-failure
 WorkingDirectory=$DESTDIR
 RuntimeDirectory=${NAME}
+TasksMax=infinity
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
@giuseppe @mrunalp @rhatdan PTAL

This is need to avoid hitting some limits when running tests and performance tests, for instance:
```
Oct 26 16:37:00.030: INFO: At 2017-10-26 16:32:06 +0000 UTC - event for example-1-pv6g7: {kubelet ip-172-18-0-172.ec2.internal} Failed: Failed to pull image "centos/mongodb-32-centos7@sha256:f06dfa5a67ac8ecb485c2545a7410b462c0dc1a98459b8e04d3b512f12e77f08": rpc error: code = 2 desc = Error writing blob: Untar error on re-exec cmd: pipe2: too many open files
```

We would need a new `cri-o-centos:latest` system container re-built with this patch (when merged) so that we won't hit any limit in the OpenShift CI. Also, it might be nice if we could ship this fix as well: https://github.com/kubernetes-incubator/cri-o/pull/1078

@giuseppe could you perhaps rebuild with the service file fix? and then we'll ask @lsm5 to rebuild with the needed CRI-O patch.

For the record, these limits are the ones we use in docker as well

Signed-off-by: Antonio Murdaca <runcom@redhat.com>