### PR TITLE
CRI-O: use 0 instead of infinity

### DIFF
--- a/cri-o-centos/service.template
+++ b/cri-o-centos/service.template
@@ -14,7 +14,7 @@ TasksMax=infinity
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
-TimeoutStartSec=infinity
+TimeoutStartSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/cri-o-fedora/service.template
+++ b/cri-o-fedora/service.template
@@ -14,7 +14,7 @@ TasksMax=infinity
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
-TimeoutStartSec=infinity
+TimeoutStartSec=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The previous PR breaks the system container on RHEL, so...
