### PR TITLE
docker-centos: use directly dockerd instead of docker daemon

### DIFF
--- a/docker-centos/init.sh
+++ b/docker-centos/init.sh
@@ -35,7 +35,7 @@ do
       sleep 0.1
 done
 
-exec /usr/bin/docker-current daemon \
+exec /usr/bin/dockerd-current \
           --config-file=/etc/docker/container-daemon.json \
           --userland-proxy-path=/usr/libexec/docker/docker-proxy-current \
           $OPTIONS \


### PR DESCRIPTION
We avoid to spawn a new process that gets a different SELinux label.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>