### PR TITLE
run kube-proxy as root

### DIFF
--- a/kubernetes-proxy/config.json.template
+++ b/kubernetes-proxy/config.json.template
@@ -6,7 +6,10 @@
     },
     "process": {
         "terminal": false,
-        "user": {},
+        "user": {
+            "uid": 0,
+            "gid": 0
+        },
         "args": [
             "/usr/bin/kube-proxy-docker.sh"
         ],

--- a/kubernetes-proxy/config.json.template
+++ b/kubernetes-proxy/config.json.template
@@ -6,10 +6,7 @@
     },
     "process": {
         "terminal": false,
-        "user": {
-            "uid": 994,
-            "gid": 996
-        },
+        "user": {},
         "args": [
             "/usr/bin/kube-proxy-docker.sh"
         ],


### PR DESCRIPTION
The 996/994 uid/gid are for the kube user and group as they are configured
in atomic hosts. When installed as rpms, the master components run as
the kube user, so I set these ids for those system containers to work that way,
too. Following that convention, though, the proxy should be running as
root, since that's how it runs when installed via RPM.