### PR TITLE
Add `[Install]` section to net-snmp service template

### DIFF
--- a/net-snmp/service.template
+++ b/net-snmp/service.template
@@ -10,3 +10,6 @@ ExecStop=$EXEC_STOP
 Restart=on-failure
 WorkingDirectory=$DESTDIR
 RuntimeDirectory=${NAME}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The net-snmp service.template file does not contain an [Install] section, so it cannot be enabled to start on reboot.

Added an Install section similar to the open-vm-tools template to allow it to be started automatically.