### PR TITLE
Update kubelet based openshift/node

### DIFF
--- a/kubernetes-kubelet/Dockerfile
+++ b/kubernetes-kubelet/Dockerfile
@@ -18,8 +18,10 @@ LABEL RUN /usr/bin/docker run -d --privileged --net=host --pid=host -v /:/rootfs
 
 COPY launch.sh /usr/bin/kubelet-docker.sh
 
-COPY service.template config.json.template /exports/
+COPY tmpfiles.template service.template config.json.template /exports/
 
-RUN mkdir -p /exports/hostfs/etc/kubernetes && cp /etc/kubernetes/{config,kubelet} /exports/hostfs/etc/kubernetes
+RUN mkdir -p /exports/hostfs/etc/cni/net.d && \
+    mkdir -p /exports/hostfs/etc/kubernetes && \
+    cp /etc/kubernetes/{config,kubelet} /exports/hostfs/etc/kubernetes
 
 ENTRYPOINT ["/usr/bin/kubelet-docker.sh"]

--- a/kubernetes-kubelet/config.json.template
+++ b/kubernetes-kubelet/config.json.template
@@ -266,26 +266,24 @@
             ]
         },
         {
+            "type": "bind",
+            "source": "/sys",
             "destination": "/sys",
-            "type": "sysfs",
-            "source": "sysfs",
             "options": [
-                "nosuid",
-                "noexec",
-                "nodev"
+                "rbind",
+                "rw"
             ]
         },
         {
-            "destination": "/sys/fs/cgroup",
-            "type": "cgroup",
-            "source": "cgroup",
-            "options": [
-                "nosuid",
-                "noexec",
-                "nodev",
-                "relatime",
-                "ro"
-            ]
+          "type": "bind",
+          "source": "/etc/cni/net.d",
+          "destination": "/etc/cni/net.d",
+          "options": [
+              "bind",
+              "slave",
+              "rw",
+              "mode=777"
+          ]
         },
         {
             "type": "bind",
@@ -298,13 +296,30 @@
             ]
          },
          {
+           "type": "bind",
+           "source": "/etc/localtime",
+           "destination": "/etc/localtime",
+           "options": [
+               "rbind",
+               "ro"
+           ]
+         },
+	 {
+	    "type": "bind",
+	    "source": "/etc/pki",
+	    "destination": "/etc/pki",
+	    "options": [
+		"bind",
+		"ro"
+	    ]
+	 },
+         {
             "destination": "/etc/resolv.conf",
             "type": "bind",
             "source": "/etc/resolv.conf",
             "options": [
                 "ro",
-                "rbind",
-                "rprivate"
+                "bind"
              ]
           },
           {
@@ -319,8 +334,8 @@
           },
           {
             "type": "bind",
-            "source": "/var/run/",
-            "destination": "/var/run/",
+            "source": "/var/run/secrets",
+            "destination": "/var/run/secrets",
             "options": [
                 "rbind",
                 "rw",
@@ -329,7 +344,7 @@
           },
           {
             "type": "bind",
-            "source": "/run",
+            "source": "${RUN_DIRECTORY}",
             "destination": "/run",
             "options": [
                 "rbind",
@@ -339,7 +354,7 @@
           },
           {
             "type": "bind",
-            "source": "/var/lib",
+            "source": "${STATE_DIRECTORY}",
             "destination": "/var/lib",
             "options": [
                 "bind",
@@ -349,7 +364,7 @@
           },
           {
             "type": "bind",
-            "source": "/var/lib/kubelet",
+            "source": "${STATE_DIRECTORY}/kubelet",
             "destination": "/var/lib/kubelet",
             "options": [
                 "rbind",
@@ -367,6 +382,15 @@
                 "rw",
                 "mode=755"
              ]
+          },
+          {
+            "destination": "/tmp",
+       	    "type": "tmpfs",
+       	    "source": "tmpfs",
+       	    "options": [
+                "mode=755",
+                "size=65536k"
+            ]
           }
     ],
     "linux": {

--- a/kubernetes-kubelet/tmpfiles.template
+++ b/kubernetes-kubelet/tmpfiles.template
@@ -1,0 +1,2 @@
+d   /var/lib/cni - - - - -
+d   /var/run/secrets - - - - -


### PR DESCRIPTION
Mount /sys/ as in node to avoid kubelet log:
Failed to get system container stats for
"/systemd/system.slice": failed to get cgroup stats
for "/systemd/system.slice": failed to get container
info for "/systemd/system.slice": unknown container
"/systemd/system.slice".

Mount /etc/pki to use the ca from the host.

Mount /var/run/secrets needed for f27 which doesn't have
kube installed and it is required by kubelet to manage
kubernetes secrets.

Mount tmp as tmpfs.

Mount cni dirs.