### PR TITLE
Add kubelet system-container ADDLT_MOUNTS

### DIFF
--- a/kubernetes-kubelet/Dockerfile
+++ b/kubernetes-kubelet/Dockerfile
@@ -18,7 +18,7 @@ LABEL RUN /usr/bin/docker run -d --privileged --net=host --pid=host -v /:/rootfs
 
 COPY launch.sh /usr/bin/kubelet-docker.sh
 
-COPY tmpfiles.template service.template config.json.template /exports/
+COPY manifest.json tmpfiles.template service.template config.json.template /exports/
 
 RUN mkdir -p /exports/hostfs/etc/cni/net.d && \
     mkdir -p /exports/hostfs/etc/kubernetes && \

--- a/kubernetes-kubelet/config.json.template
+++ b/kubernetes-kubelet/config.json.template
@@ -392,6 +392,7 @@
                 "size=65536k"
             ]
           }
+          $ADDTL_MOUNTS
     ],
     "linux": {
         "rootfsPropagation": "rslave",

--- a/kubernetes-kubelet/manifest.json
+++ b/kubernetes-kubelet/manifest.json
@@ -1,0 +1,6 @@
+{
+    "version": "1.0",
+    "defaultValues": {
+        "ADDTL_MOUNTS": ""
+    }
+}


### PR DESCRIPTION
This commit allows kubelet system-containers
to accept additional mounts during creation.

This implements the same interface as the etcd
system container: https://github.com/projectatomic/atomic-system-containers/blob/master/etcd/config.json.template#L219

Signed-off-by: Spyros Trigazis <spyridon.trigazis@cern.ch>