### PR TITLE
buildah: few fixes

### DIFF
--- a/buildah-fedora/Dockerfile
+++ b/buildah-fedora/Dockerfile
@@ -12,4 +12,5 @@ RUN mkdir /exports /host && \
 # system container
 COPY config.json.template /exports/
 
-CMD ["/usr/bin/false"]
+CMD ["--help"]
+ENTRYPOINT ["/usr/bin/buildah"]

--- a/buildah-fedora/config.json.template
+++ b/buildah-fedora/config.json.template
@@ -374,6 +374,16 @@
 	    "options": [
 		"private"
 	    ]
+	},
+	{
+	    "source": "/etc",
+	    "destination": "/etc",
+	    "type": "bind",
+	    "options": [
+                "rbind",
+		"slave",
+                "ro"
+	    ]
 	}
     ],
     "hooks": {},


### PR DESCRIPTION
a couple of fixes in the Buildah system container:

1) Set CMD/ENTRYPOINT so it can be used as a Docker container as well
2) Mount `/etc` from the host so to inherit all the configuration in the container