### PR TITLE
kubelet: Add ${STATE_DIR}/kubelet to tmpfiles

### DIFF
--- a/kubernetes-kubelet/tmpfiles.template
+++ b/kubernetes-kubelet/tmpfiles.template
@@ -1,2 +1,3 @@
+d   ${STATE_DIRECTORY}/kubelet - - - - -
 d   /var/lib/cni - - - - -
 d   /var/run/secrets - - - - -


### PR DESCRIPTION
In f27 /var/lib/kubelet doesn't exists, we need
to create it.