### PR TITLE
buildah: bind mount `/var/run/NetworkManager`

### DIFF
--- a/buildah-fedora/Dockerfile
+++ b/buildah-fedora/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir /exports /host && \
     dnf clean all
 
 # system container
-COPY config.json.template /exports/
+COPY config.json.template tmpfiles.template /exports/
 
 CMD ["--help"]
 ENTRYPOINT ["/usr/bin/buildah"]

--- a/buildah-fedora/Dockerfile
+++ b/buildah-fedora/Dockerfile
@@ -6,7 +6,7 @@ LABEL com.redhat.component="buildah" \
       atomic.type="system"
 
 RUN mkdir /exports /host && \
-    dnf install --setopt=tsflags=nodocs -y buildah && \
+    dnf install --setopt=tsflags=nodocs -y buildah bwrap-oci && \
     dnf clean all
 
 # system container

--- a/buildah-fedora/config.json.template
+++ b/buildah-fedora/config.json.template
@@ -384,6 +384,16 @@
 		"slave",
                 "ro"
 	    ]
+	},
+	{
+	    "source": "/var/run/NetworkManager",
+	    "destination": "/var/run/NetworkManager",
+	    "type": "bind",
+	    "options": [
+                "rbind",
+		"slave",
+                "ro"
+	    ]
 	}
     ],
     "hooks": {},

--- a/buildah-fedora/tmpfiles.template
+++ b/buildah-fedora/tmpfiles.template
@@ -1,0 +1,1 @@
+d    /var/run/NetworkManager               -        -           -       - -


### PR DESCRIPTION
bind mount `/var/run/NetworkManager` from the host so that even in the rootless case `/etc/resolv.conf` points to the correct file.

Also, add `bwrap-oci` inside the container for using it as an alternative OCI runtime