### PR TITLE
docker: add support for additional mounts

### DIFF
--- a/docker-centos/Dockerfile
+++ b/docker-centos/Dockerfile
@@ -19,7 +19,7 @@ yum clean all
 ADD init.sh /usr/bin
 
 # system container
-COPY service.template tmpfiles.template config.json.template /exports/
+COPY service.template tmpfiles.template config.json.template manifest.json /exports/
 COPY daemon.json /exports/hostfs/etc/docker/container-daemon.json
 # Copy /etc/oci-umount.conf over if it exists
 RUN (test -e /etc/oci-umount.conf && cp /etc/oci-umount.conf /exports/hostfs/etc) || true

--- a/docker-centos/config.json.template
+++ b/docker-centos/config.json.template
@@ -351,6 +351,7 @@
 		"private"
 	    ]
 	}
+        $ADDTL_MOUNTS
     ],
     "hooks": {},
     "linux": {

--- a/docker-centos/config.json.template
+++ b/docker-centos/config.json.template
@@ -281,6 +281,17 @@
 	},
 	{
 	    "type": "bind",
+	    "source": "/opt",
+	    "destination": "/opt",
+	    "options": [
+		"rbind",
+		"rslave",
+		"rw",
+		"mode=755"
+	    ]
+	},
+	{
+	    "type": "bind",
 	    "source": "/mnt",
 	    "destination": "/mnt",
 	    "options": [

--- a/docker-centos/manifest.json
+++ b/docker-centos/manifest.json
@@ -1,0 +1,7 @@
+{
+    "version": "1.0",
+    "defaultValues": {
+	"ADDTL_MOUNTS": ""
+    }
+}
+

--- a/docker-fedora/Dockerfile
+++ b/docker-fedora/Dockerfile
@@ -23,7 +23,7 @@ COPY shim.sh init.sh /usr/bin/
 
 # system container
 COPY set_mounts.sh /
-COPY config.json.template service.template tmpfiles.template /exports/
+COPY config.json.template service.template tmpfiles.template manifest.json /exports/
 COPY daemon.json /exports/hostfs/etc/docker/container-daemon.json
 # https://github.com/rhatdan/oci-umount/issues/2
 # Copy config if available

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -367,6 +367,7 @@
 		"private"
 	    ]
 	}
+        $ADDTL_MOUNTS
     ],
     "hooks": {},
     "linux": {

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -286,6 +286,17 @@
 	},
 	{
 	    "type": "bind",
+	    "source": "/opt",
+	    "destination": "/opt",
+	    "options": [
+		"rbind",
+		"rslave",
+		"rw",
+		"mode=755"
+	    ]
+	},
+	{
+	    "type": "bind",
 	    "source": "/mnt",
 	    "destination": "/mnt",
 	    "options": [

--- a/docker-fedora/manifest.json
+++ b/docker-fedora/manifest.json
@@ -1,0 +1,7 @@
+{
+    "version": "1.0",
+    "defaultValues": {
+	"ADDTL_MOUNTS": ""
+    }
+}
+


### PR DESCRIPTION
use the same pattern used for the `etcd` system container.

Additional mounts can be configured with `--set` at installation time