### PR TITLE
etcd: make sure /etcd is owned by HOST_UID/HOST_GID

### DIFF
--- a/etcd/tmpfiles.template
+++ b/etcd/tmpfiles.template
@@ -1,3 +1,4 @@
+d    ${STATE_DIRECTORY}/etcd                0700 ${HOST_UID} ${HOST_GID} - -
 d    ${STATE_DIRECTORY}/etcd/${NAME}.etcd   0700 ${HOST_UID} ${HOST_GID} - -
 Z    ${STATE_DIRECTORY}/etcd/${NAME}.etcd   0700 ${HOST_UID} ${HOST_GID} - -
 d    ${RUN_DIRECTORY}/${NAME}               -        -           -       - -


### PR DESCRIPTION
Atomic resets /var/lib/etcd to be owned by etcd:etcd, which breaks
etcd system container after reboot

Related to https://github.com/openshift/openshift-ansible/pull/7443
See https://bugzilla.redhat.com/show_bug.cgi?id=1553084