### PR TITLE
docker: specify --bind-mount-prefix=/host

### DIFF
--- a/docker-centos/config.json.template
+++ b/docker-centos/config.json.template
@@ -343,6 +343,16 @@
 		"mode=755"
 	    ]
 	},
+        {
+            "destination": "/host",
+            "options": [
+                "rbind",
+                "rshared",
+                "rw"
+            ],
+            "source": "/",
+            "type": "bind"
+        },
 	{
 	    "source": "/sys",
 	    "destination": "/sys",

--- a/docker-centos/init.sh
+++ b/docker-centos/init.sh
@@ -36,6 +36,7 @@ do
 done
 
 exec /usr/bin/dockerd-current \
+          --bind-mount-prefix=/host \
           --config-file=/etc/docker/container-daemon.json \
           --userland-proxy-path=/usr/libexec/docker/docker-proxy-current \
           $OPTIONS \

--- a/docker-fedora/config.json.template
+++ b/docker-fedora/config.json.template
@@ -348,6 +348,16 @@
 		"rw"
 	    ]
 	},
+        {
+            "destination": "/host",
+            "options": [
+                "rbind",
+                "rshared",
+                "rw"
+            ],
+            "source": "/",
+            "type": "bind"
+        },
 	{
 	    "source": "/dev",
 	    "destination": "/dev",

--- a/docker-fedora/init.sh
+++ b/docker-fedora/init.sh
@@ -38,6 +38,7 @@ do
 done
 
 exec /usr/bin/dockerd-current \
+     --bind-mount-prefix=/host \
      --config-file=/etc/docker/container-daemon.json \
      $OPTIONS \
      $DOCKER_STORAGE_OPTIONS \


### PR DESCRIPTION
so that we are able to access all the paths on the host from the system container.

Depends on:

https://github.com/projectatomic/docker/pull/308

Let's not merge this yet, and wait for the change to be propagated into the packages first